### PR TITLE
feat: migrate from zod to standard schema

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -15,6 +15,6 @@
 	},
 	"dependencies": {
 		"@better-fetch/fetch": "workspace:*",
-		"zod": "^3.23.8"
+		"zod": "^3.24.0"
 	}
 }

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -1,27 +1,27 @@
 {
-  "compilerOptions": {
-    // Enable latest features
-    "lib": ["ESNext", "DOM"],
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
+	"compilerOptions": {
+		// Enable latest features
+		"lib": ["ESNext", "DOM"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
 
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
 
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
 
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  }
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	}
 }

--- a/doc/app/page.tsx
+++ b/doc/app/page.tsx
@@ -7,32 +7,95 @@ import { Banner } from "fumadocs-ui/components/banner";
 import Link from "next/link";
 
 export default function HomePage() {
-	return (
-		<div className="relative min-h-screen flex w-full items-center justify-center overflow-hidden rounded-lg border bg-background p-20 md:shadow-xl">
-			<Ripple />
-			<div className="z-10 flex flex-col items-center justify-center">
-				<h1 className="mb-4 text-5xl font-bold text-center">Better Fetch</h1>
+	const installCode = `npm install @better-fetch/fetch
+# Then install your preferred validator
+npm install zod # or valibot, arktype, etc.`;
 
-				<p className="text-muted-foreground mx-auto max-w-2xl text-center">
-					Advanced fetch wrapper for typescript with zod schema validations,
-					pre-defined routes, callbacks, plugins and more.
+	const usageExample = `import { betterFetch } from '@better-fetch/fetch';
+import { z } from 'zod'; // or your preferred validator
+
+const { data, error } = await betterFetch("https://api.example.com/todos/1", {
+	output: z.object({
+		id: z.number(),
+		title: z.string(),
+		completed: z.boolean()
+	})
+});`;
+
+	return (
+		<div className="relative min-h-screen flex w-full flex-col items-center justify-start overflow-hidden rounded-lg border bg-background p-8 md:p-20">
+			<Ripple />
+
+			{/* Hero Section */}
+			<div className="z-10 flex flex-col items-center justify-center max-w-4xl">
+				<h1 className="mb-4 text-6xl font-bold text-center bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/60">
+					Better Fetch
+				</h1>
+				<p className="mb-6 text-2xl font-semibold text-center">
+					Type-Safe API Calls with Your Favorite Validator
 				</p>
-				<div className="flex py-4 items-center justify-center gap-4 w-full">
+				<p className="text-muted-foreground mx-auto max-w-2xl text-center text-lg mb-8">
+					A modern fetch wrapper that works with any Standard Schema validator.
+					Use Zod, Valibot, ArkType, or any spec-compliant library for powerful
+					runtime validations and perfect TypeScript inference.
+				</p>
+
+				<div className="flex py-4 items-center justify-center gap-4 w-full mb-12">
 					<Link href="/docs">
-						<Button className="flex gap-2 cursor-pointer">
+						<Button size="lg" className="flex gap-2 cursor-pointer">
 							<Icons.docs />
-							Docs
+							Get Started
 						</Button>
 					</Link>
 					<Link href="https://github.com/bekacru/better-fetch">
-						<Button className="flex gap-2" variant="secondary">
+						<Button size="lg" className="flex gap-2" variant="secondary">
 							<Icons.github />
-							Github
+							GitHub
 						</Button>
 					</Link>
 				</div>
+
+				{/* Feature Grid */}
+				<div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12 w-full">
+					{[
+						{
+							title: "Schema Agnostic",
+							description:
+								"Works with Zod, Valibot, ArkType, and any Standard Schema validator",
+						},
+						{
+							title: "Type Safety",
+							description:
+								"Full TypeScript inference with your preferred validation library",
+						},
+						{
+							title: "Runtime Validation",
+							description:
+								"Automatic request/response validation with detailed error messages",
+						},
+						{
+							title: "Pre-defined Routes",
+							description: "Define API schemas once, use them everywhere",
+						},
+						{
+							title: "Universal",
+							description:
+								"Works in browsers, Node.js, Deno, Bun, and edge runtimes",
+						},
+						{
+							title: "Advanced Features",
+							description: "Retries, timeouts, hooks, plugins, and more",
+						},
+					].map((feature) => (
+						<div key={feature.title} className="p-6 rounded-lg border bg-card">
+							<h3 className="font-semibold mb-2">{feature.title}</h3>
+							<p className="text-sm text-muted-foreground">
+								{feature.description}
+							</p>
+						</div>
+					))}
+				</div>
 			</div>
-			<div></div>
 		</div>
 	);
 }

--- a/doc/app/page.tsx
+++ b/doc/app/page.tsx
@@ -1,101 +1,35 @@
 import { Icons } from "@/components/icons";
-import AnimatedGridPattern from "@/components/landing/grid";
 import Ripple from "@/components/landing/ripple";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { Banner } from "fumadocs-ui/components/banner";
 import Link from "next/link";
 
 export default function HomePage() {
-	const installCode = `npm install @better-fetch/fetch
-# Then install your preferred validator
-npm install zod # or valibot, arktype, etc.`;
-
-	const usageExample = `import { betterFetch } from '@better-fetch/fetch';
-import { z } from 'zod'; // or your preferred validator
-
-const { data, error } = await betterFetch("https://api.example.com/todos/1", {
-	output: z.object({
-		id: z.number(),
-		title: z.string(),
-		completed: z.boolean()
-	})
-});`;
-
 	return (
-		<div className="relative min-h-screen flex w-full flex-col items-center justify-start overflow-hidden rounded-lg border bg-background p-8 md:p-20">
+		<div className="relative min-h-screen flex w-full items-center justify-center overflow-hidden rounded-lg border bg-background p-20 md:shadow-xl">
 			<Ripple />
+			<div className="z-10 flex flex-col items-center justify-center">
+				<h1 className="mb-4 text-5xl font-bold text-center">Better Fetch</h1>
 
-			{/* Hero Section */}
-			<div className="z-10 flex flex-col items-center justify-center max-w-4xl">
-				<h1 className="mb-4 text-6xl font-bold text-center bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/60">
-					Better Fetch
-				</h1>
-				<p className="mb-6 text-2xl font-semibold text-center">
-					Type-Safe API Calls with Your Favorite Validator
+				<p className="text-muted-foreground mx-auto max-w-2xl text-center">
+					Advanced fetch wrapper for typescript with standard schema validations (using zod, valibot, arktype or any other compliant validator),
+					pre-defined routes, callbacks, plugins and more.
 				</p>
-				<p className="text-muted-foreground mx-auto max-w-2xl text-center text-lg mb-8">
-					A modern fetch wrapper that works with any Standard Schema validator.
-					Use Zod, Valibot, ArkType, or any spec-compliant library for powerful
-					runtime validations and perfect TypeScript inference.
-				</p>
-
-				<div className="flex py-4 items-center justify-center gap-4 w-full mb-12">
+				<div className="flex py-4 items-center justify-center gap-4 w-full">
 					<Link href="/docs">
-						<Button size="lg" className="flex gap-2 cursor-pointer">
+						<Button className="flex gap-2 cursor-pointer">
 							<Icons.docs />
-							Get Started
+							Docs
 						</Button>
 					</Link>
 					<Link href="https://github.com/bekacru/better-fetch">
-						<Button size="lg" className="flex gap-2" variant="secondary">
+						<Button className="flex gap-2" variant="secondary">
 							<Icons.github />
-							GitHub
+							Github
 						</Button>
 					</Link>
 				</div>
-
-				{/* Feature Grid */}
-				<div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12 w-full">
-					{[
-						{
-							title: "Schema Agnostic",
-							description:
-								"Works with Zod, Valibot, ArkType, and any Standard Schema validator",
-						},
-						{
-							title: "Type Safety",
-							description:
-								"Full TypeScript inference with your preferred validation library",
-						},
-						{
-							title: "Runtime Validation",
-							description:
-								"Automatic request/response validation with detailed error messages",
-						},
-						{
-							title: "Pre-defined Routes",
-							description: "Define API schemas once, use them everywhere",
-						},
-						{
-							title: "Universal",
-							description:
-								"Works in browsers, Node.js, Deno, Bun, and edge runtimes",
-						},
-						{
-							title: "Advanced Features",
-							description: "Retries, timeouts, hooks, plugins, and more",
-						},
-					].map((feature) => (
-						<div key={feature.title} className="p-6 rounded-lg border bg-card">
-							<h3 className="font-semibold mb-2">{feature.title}</h3>
-							<p className="text-sm text-muted-foreground">
-								{feature.description}
-							</p>
-						</div>
-					))}
-				</div>
 			</div>
+			<div></div>
 		</div>
 	);
 }

--- a/doc/content/docs/default-types.mdx
+++ b/doc/content/docs/default-types.mdx
@@ -6,7 +6,9 @@ description: Default Types
 
 ## Default Output
 
-By default, the response data will always be type of `unknown`. If you want to customize the default type you can pass the `defaultOutput` option to the `createFetch` function.
+By default, the response data will always be of type `unknown`. If you want to customize the default type you can pass the `defaultOutput` option to the `createFetch` function.
+Note: When you supply a custom output schema using a Standard Schema validator (for example, zod or any alternative),
+the provided output schema will override the `defaultOutput` type. This approach offers a strongly typed solution without locking you to a single library.
 
 <Callout type="info">
 This only serves as a type for the response data it's not used as a validation schema.
@@ -14,7 +16,8 @@ This only serves as a type for the response data it's not used as a validation s
 
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";
-import { z } from "zod";
+// Example using zod (or any Standard Schema compliant library)
+import { z } from "zod"; 
 
 const $fetch = createFetch({
     baseURL: "https://jsonplaceholder.typicode.com",
@@ -52,10 +55,12 @@ const { data, error } = await $fetch("/todos/1", {
 
 The default error type is:
 ```ts
-{ status: number, statusText: string, message?: string }. 
+{ status: number, statusText: string, message?: string }
 ```
 
-if you want custom default error type, you can pass a `defaultError` option to the `createFetch` function. 
+If you want a custom error type, you can pass a `defaultError` option to the `createFetch` function.
+Remember: Your custom error type builds on top of the default properties, and if your API returns a JSON error,
+// it will be merged with your definition.
 
 <Callout type="info">
 The `status` and `statusText` properties are always defined. Your custom error definitions are only
@@ -64,7 +69,7 @@ inferred if the API returns a JSON error object.
 
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";
-import { z } from "zod";
+import { z } from "zod"; // Example only
 
 const $fetch = createFetch({
     baseURL: "https://jsonplaceholder.typicode.com",

--- a/doc/content/docs/dynamic-parameters.mdx
+++ b/doc/content/docs/dynamic-parameters.mdx
@@ -3,7 +3,7 @@ title: Dynamic Parameters
 description: Dynamic Parameters
 ---
 
-Dynamic parameters are parameters that are defined in the url path. They are defined using the `:` prefix. When the request is made, the dynamic paramters will be replaced with the values passed in the `params` option.
+Dynamic parameters are parameters that are defined in the url path. They are defined using the `:` prefix. When the request is made, the dynamic parameters will be replaced with the values passed in the `params` option.
 
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";

--- a/doc/content/docs/fetch-schema.mdx
+++ b/doc/content/docs/fetch-schema.mdx
@@ -3,11 +3,11 @@ title: Fetch Schema
 description: Fetch Schema
 ---
 
-Fetch schema allows you to pre-define the url path and the shape of request and response data. You can easily document your api using this schema. 
+Fetch schema allows you to pre-define the URL path and the shape of request and response data. You can easily document your API using this schema.
 
-The output of the schema will be validated using zod and if the validation fails, it'll throw an error. 
+Better Fetch now uses Standard Schema internally, allowing you to bring your own Standard Schema-compliant validator (e.g., Zod, Valibot, ArkType).
 
-Before we start, make sure you have installed the [zod](https://www.npmjs.com/package/zod) package.
+To create a fetch schema, you need to import the `createSchema` function from `@better-fetch/fetch`.
 
 ```package-install
 npm i zod

--- a/doc/content/docs/getting-started.mdx
+++ b/doc/content/docs/getting-started.mdx
@@ -9,24 +9,19 @@ description: Getting started with Better Fetch
 npm i @better-fetch/fetch
 ```
 
-*You also need to have [zod](https://www.npmjs.com/package/zod) installed for schema validations. If you don't plan to use zod for schema validation, you can install it as a dev dependency.*
-
 ```package-install
-npm i zod
+npm i Schema-validation-of-your-choice
 ```
 
 ### Quick Start
 
-The fastest way to start using better fetch is to import the `betterFetch` function and start making requests.
-
-You can define the response type using generics or **zod schema (recommended)**.
+The fastest way to start using Better Fetch is to import the `betterFetch` function.
+You can define the response type using generics or use a schema that supports Standard Schema (recommended).
 
 ```ts twoslash title="fetch.ts"
 import { betterFetch } from '@better-fetch/fetch';
-import { z } from 'zod';
 
-
-//Using generic type
+// Using generic type
 const { data, error } = await betterFetch<{
     userId: string;
     id: number;
@@ -35,8 +30,10 @@ const { data, error } = await betterFetch<{
 }>("https://jsonplaceholder.typicode.com/todos/1");
 
 
-//Using zod schema
-const { data: todos, error: todoError } = await betterFetch("https://jsonplaceholder.typicodei.com/todos/1", {
+// Using a Standard Schema validator (for example, zod)
+import { z } from 'zod'; // or your preferred Standard Schema compliant library
+
+const { data: todos, error: todoError } = await betterFetch("https://jsonplaceholder.typicode.com/todos/1", {
     output: z.object({
         userId: z.string(),
         id: z.number(),
@@ -44,12 +41,11 @@ const { data: todos, error: todoError } = await betterFetch("https://jsonplaceho
         completed: z.boolean(),
     })  
 });
-
 // @annotate: Hover over the data object to see the type
 ```
 
 <Callout type="info"> 
-  Make sure strict mode is enabled in your tsconfig when using zod schema validations.
+  Make sure strict mode is enabled in your tsconfig when using schema validations.
 </Callout>
 
 Better fetch by default returns a `Promise` that resolves to an object of `data` and `error` but if you pass the `throw` option, it will return the parsed response data only. 
@@ -108,13 +104,15 @@ Fetch schema enables you to pre-define the URL path and the shape of request and
    Plugins can also define fetch schemas. See [Plugins](/docs/plugins) section for more details.
 </Callout>
 
-The output of the scheam will be validated using zod and if the validation fails, it'll throw an error.
+The output of the scheam will be validated using your schema and if the validation fails, it'll throw an error.
 
 ```ts twoslash title="fetch.ts" 
 import { createSchema, createFetch } from "@better-fetch/fetch";
+
+// ZOD example
 import { z } from "zod";
 
-export const schema = createSchema({ // [!code highlight]
+export const zodSchema = createSchema({ // [!code highlight]
     "/path": { // [!code highlight]
         input: z.object({ // [!code highlight]
             userId: z.string(), // [!code highlight]
@@ -133,7 +131,7 @@ export const schema = createSchema({ // [!code highlight]
 
 const $fetch = createFetch({
     baseURL: "https://jsonplaceholder.typicode.com",
-    schema: schema // [!code highlight]
+    schema: zodSchema // [!code highlight]
 });
 
 const { data, error } = await $fetch("/path", {

--- a/doc/content/docs/getting-started.mdx
+++ b/doc/content/docs/getting-started.mdx
@@ -9,8 +9,10 @@ description: Getting started with Better Fetch
 npm i @better-fetch/fetch
 ```
 
+If you plan to use runtime validation, you need to install [standard schema](https://github.com/standard-schema/standard-schema) compliant validator like [zod](https://github.com/colinhacks/zod), [valibot](https://valibot.dev), [arktype](https://github.com/arktypeio/arktype) and so on.
+
 ```package-install
-npm i Schema-validation-of-your-choice
+npm i zod # valibot, arktype...
 ```
 
 ### Quick Start
@@ -44,8 +46,8 @@ const { data: todos, error: todoError } = await betterFetch("https://jsonplaceho
 // @annotate: Hover over the data object to see the type
 ```
 
-<Callout type="info"> 
-  Make sure strict mode is enabled in your tsconfig when using schema validations.
+<Callout type="warn"> 
+  Make sure `strict` mode is enabled in your tsconfig when using schema validations.
 </Callout>
 
 Better fetch by default returns a `Promise` that resolves to an object of `data` and `error` but if you pass the `throw` option, it will return the parsed response data only. 

--- a/doc/content/docs/index.mdx
+++ b/doc/content/docs/index.mdx
@@ -3,13 +3,19 @@ title: Introduction
 description: Getting started with Better Fetch
 ---
 
-Better fetch is advanced fetch wrapper for typescript. It supports error as value, zod schema validations, advanced type inference, pre-defined routes, hooks, plugins and more. Works on the browser, node (version 18+), workers, deno and bun.
+# Better Fetch
+
+Better Fetch is an advanced fetch wrapper for TypeScript that supports any Standard Schema-compliant validator (like Zod, Valibot, ArkType, etc) for runtime validation and type inference. It features error-as-value handling, pre-defined routes, hooks, plugins and more. Works on the browser, node (version 18+), workers, deno and bun.
 
 ## Features
 <Cards>
     <Card
+        title="Schema Agnostic"
+        description="Use any Standard Schema compatible validator (Zod, Valibot, ArkType, etc) for runtime validation and type inference."
+    />
+    <Card
         title="Type safety"
-        description="Advanced type inference and runtime validations with zod"
+        description="Harness advanced type inference and runtime validations powered by Standard Schema. Bring your validator of choice as long as it supports standard schema interfaces."
     />
     <Card
         title="Smart Parser"
@@ -17,7 +23,7 @@ Better fetch is advanced fetch wrapper for typescript. It supports error as valu
     />
     <Card
         title="Fetch Schema"
-        description="Pre defined routes with zod schema validations"
+        description="Pre defined routes with schema validations"
         href="/docs/fetch-schema"
     />
     <Card

--- a/doc/content/docs/index.mdx
+++ b/doc/content/docs/index.mdx
@@ -11,11 +11,11 @@ Better Fetch is an advanced fetch wrapper for TypeScript that supports any Stand
 <Cards>
     <Card
         title="Schema Agnostic"
-        description="Use any Standard Schema compatible validator (Zod, Valibot, ArkType, etc) for runtime validation and type inference."
+        description="Use any Standard Schema compatible validator (Zod, Valibot, ArkType, etc)."
     />
     <Card
         title="Type safety"
-        description="Harness advanced type inference and runtime validations powered by Standard Schema. Bring your validator of choice as long as it supports standard schema interfaces."
+        description="Advanced type inference and runtime validations powered by Standard Schema."
     />
     <Card
         title="Smart Parser"
@@ -33,12 +33,12 @@ Better Fetch is an advanced fetch wrapper for TypeScript that supports any Stand
     />
     <Card
         title="Advanced Retry"
-        description="Advanced retry mechanisms with linear and exponential backoff strategies or custom retry conditions"
+        description="Advanced retry mechanisms"
         href="/docs/timeout-and-retry"
     />
     <Card
         title="Compatible with fetch and fetch-like APIs"
-        description="Wraps around fetch and works on the browser, node (version 18+), workers, deno and bun out of the box but can also use custom fetch implementations like node-fetch"
+        description="Wraps around fetch and works on the browser, node (version 18+), workers, deno and bun."
     />
 </Cards>
 

--- a/doc/content/docs/plugins.mdx
+++ b/doc/content/docs/plugins.mdx
@@ -79,10 +79,14 @@ const $fetch = createFetch({
 
 ### Schema
 
-You can define a schema for a plugin. This allows you to easily document the api usage using a schema.
+You can define a schema for a plugin. This allows you to easily document the API usage using a schema.
+The schema is now based on the Standard Schema specification.
+
+Note: Better Fetch now uses Standard Schema internally so you can bring your own Standard Schema–compliant validator. You are no longer limited to zod.
 
 ```ts twoslash title="fetch.ts"
 import { createFetch, createSchema, BetterFetchPlugin } from "@better-fetch/fetch";
+// Example using zod (or any Standard Schema compliant validator)
 import { z } from "zod";
 // @errors: 2353 2561
 const plugin = {

--- a/doc/next-env.d.ts
+++ b/doc/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/doc/package.json
+++ b/doc/package.json
@@ -27,7 +27,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tailwind-merge": "^2.4.0",
-		"zod": "^3.23.8"
+		"zod": "^3.24.0"
 	},
 	"devDependencies": {
 		"@types/mdx": "^2.0.13",

--- a/doc/package.json
+++ b/doc/package.json
@@ -9,8 +9,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@better-fetch/fetch": "^1.1.0",
-		"@better-fetch/logger": "^1.1.0",
+		"@better-fetch/fetch": "workspace:*",
+		"@better-fetch/logger": "workspace:*",
 		"@radix-ui/react-icons": "^1.3.0",
 		"@radix-ui/react-slot": "^1.1.0",
 		"class-variance-authority": "^0.7.0",
@@ -26,7 +26,7 @@
 		"next": "^14.2.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"tailwind-merge": "^2.4.0",
+		"tailwind-merge": "^2.5.2",
 		"zod": "^3.24.0"
 	},
 	"devDependencies": {

--- a/packages/better-fetch/package.json
+++ b/packages/better-fetch/package.json
@@ -32,7 +32,7 @@
 		"type-fest": "^4.23.0",
 		"typescript": "^5.4.5",
 		"vitest": "^1.5.0",
-		"zod": "^3.23.6"
+		"zod": "^3.24.0"
 	},
 	"exports": {
 		".": {
@@ -41,5 +41,8 @@
 		}
 	},
 	"files": ["dist"],
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@standard-schema/spec": "^1.0.0"
+	}
 }

--- a/packages/better-fetch/package.json
+++ b/packages/better-fetch/package.json
@@ -2,6 +2,7 @@
 	"name": "@better-fetch/fetch",
 	"version": "1.1.13-beta.4",
 	"main": "./dist/index.cjs",
+	"type": "module",
 	"module": "./dist/index.js",
 	"react-native": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -32,7 +33,7 @@
 		"type-fest": "^4.23.0",
 		"typescript": "^5.4.5",
 		"vitest": "^1.5.0",
-		"zod": "^3.24.0"
+		"zod": "^3.24.1"
 	},
 	"exports": {
 		".": {
@@ -40,9 +41,5 @@
 			"require": "./dist/index.cjs"
 		}
 	},
-	"files": ["dist"],
-	"type": "module",
-	"dependencies": {
-		"@standard-schema/spec": "^1.0.0"
-	}
+	"files": ["dist"]
 }

--- a/packages/better-fetch/src/create-fetch/index.ts
+++ b/packages/better-fetch/src/create-fetch/index.ts
@@ -1,6 +1,7 @@
 import { betterFetch } from "../fetch";
 import { BetterFetchPlugin } from "../plugins";
 import type { BetterFetchOption } from "../types";
+import { parseStandardSchema } from "../utils";
 import type { BetterFetch, CreateFetchOption } from "./types";
 
 export const applySchemaPlugin = (config: CreateFetchOption) =>
@@ -42,13 +43,13 @@ export const applySchemaPlugin = (config: CreateFetchOption) =>
 						opts = {
 							...opts,
 							body: keySchema.input
-								? keySchema.input.parse(options?.body)
+								? await parseStandardSchema(keySchema.input, options?.body)
 								: options?.body,
 							params: keySchema.params
-								? keySchema.params.parse(options?.params)
+								? await parseStandardSchema(keySchema.params, options?.params)
 								: options?.params,
 							query: keySchema.query
-								? keySchema.query.parse(options?.query)
+								? await parseStandardSchema(keySchema.query, options?.query)
 								: options?.query,
 						};
 					}

--- a/packages/better-fetch/src/create-fetch/schema.ts
+++ b/packages/better-fetch/src/create-fetch/schema.ts
@@ -5,7 +5,7 @@ export type FetchSchema = {
 	input?: StandardSchemaV1;
 	output?: StandardSchemaV1;
 	query?: StandardSchemaV1;
-	params?:  StandardSchemaV1<Record<string, unknown>> | undefined;
+	params?: StandardSchemaV1<Record<string, unknown>> | undefined;
 	method?: Methods;
 };
 

--- a/packages/better-fetch/src/create-fetch/schema.ts
+++ b/packages/better-fetch/src/create-fetch/schema.ts
@@ -1,19 +1,11 @@
-import type { ZodSchema, z } from "zod";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { StringLiteralUnion } from "../type-utils";
 
 export type FetchSchema = {
-	input?: ZodSchema;
-	output?: ZodSchema;
-	query?: ZodSchema;
-	params?:
-		| z.ZodObject<{
-				[key: string]: ZodSchema;
-		  }>
-		| z.ZodOptional<
-				z.ZodObject<{
-					[key: string]: ZodSchema;
-				}>
-		  >;
+	input?: StandardSchemaV1;
+	output?: StandardSchemaV1;
+	query?: StandardSchemaV1;
+	params?:  StandardSchemaV1<Record<string, unknown>> | undefined;
 	method?: Methods;
 };
 

--- a/packages/better-fetch/src/create-fetch/schema.ts
+++ b/packages/better-fetch/src/create-fetch/schema.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { StandardSchemaV1 } from "../standard-schema";
 import type { StringLiteralUnion } from "../type-utils";
 
 export type FetchSchema = {

--- a/packages/better-fetch/src/create-fetch/types.ts
+++ b/packages/better-fetch/src/create-fetch/types.ts
@@ -1,5 +1,5 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { IsEmptyObject } from "type-fest";
-import type { ZodSchema, z } from "zod";
 import { BetterFetchPlugin } from "../plugins";
 import type { Prettify, StringLiteralUnion } from "../type-utils";
 import type { BetterFetchOption, BetterFetchResponse } from "../types";
@@ -11,14 +11,16 @@ export type CreateFetchOption = BetterFetchOption & {
 	 * @default false
 	 */
 	catchAllError?: boolean;
-	defaultOutput?: ZodSchema;
-	defaultError?: ZodSchema;
+	defaultOutput?: StandardSchemaV1;
+	defaultError?: StandardSchemaV1;
 };
 
 export type WithRequired<T, K extends keyof T | never> = T & {
 	[P in K]-?: T[P];
 };
-export type InferBody<T> = T extends ZodSchema ? z.input<T> : any;
+export type InferBody<T> = T extends StandardSchemaV1
+	? StandardSchemaV1.InferInput<T>
+	: any;
 
 export type RemoveEmptyString<T> = T extends string
 	? "" extends T
@@ -39,8 +41,8 @@ export type InferParamPath<Path> =
 				? InferParamPath<Rest>
 				: {};
 
-export type InferParam<Path, Param> = Param extends ZodSchema
-	? z.input<Param>
+export type InferParam<Path, Param> = Param extends StandardSchemaV1
+	? StandardSchemaV1.InferInput<Param>
 	: InferParamPath<Path>;
 
 export type InferOptions<T extends FetchSchema, Key, Res = any> = WithRequired<
@@ -55,10 +57,12 @@ export type InferOptions<T extends FetchSchema, Key, Res = any> = WithRequired<
 		: never
 >;
 
-export type InferQuery<Q> = Q extends z.ZodSchema ? z.input<Q> : any;
+export type InferQuery<Q> = Q extends StandardSchemaV1
+	? StandardSchemaV1.InferInput<Q>
+	: any;
 
-export type IsFieldOptional<T> = T extends z.ZodSchema
-	? T extends z.ZodOptional<any>
+export type IsFieldOptional<T> = T extends StandardSchemaV1
+	? undefined extends T
 		? true
 		: false
 	: true;
@@ -147,8 +151,8 @@ export type InferPluginOptions<Options extends CreateFetchOption> =
 	Options["plugins"] extends Array<infer P>
 		? P extends BetterFetchPlugin
 			? P["getOptions"] extends () => infer O
-				? O extends ZodSchema
-					? UnionToIntersection<z.infer<O>>
+				? O extends StandardSchemaV1
+					? UnionToIntersection<StandardSchemaV1.InferOutput<O>>
 					: {}
 				: {}
 			: {}
@@ -156,11 +160,11 @@ export type InferPluginOptions<Options extends CreateFetchOption> =
 
 export type BetterFetch<
 	CreateOptions extends CreateFetchOption = CreateFetchOption,
-	DefaultRes = CreateOptions["defaultOutput"] extends ZodSchema
-		? z.infer<CreateOptions["defaultOutput"]>
+	DefaultRes = CreateOptions["defaultOutput"] extends StandardSchemaV1
+		? StandardSchemaV1.InferOutput<CreateOptions["defaultOutput"]>
 		: unknown,
-	DefaultErr = CreateOptions["defaultError"] extends ZodSchema
-		? z.infer<CreateOptions["defaultError"]>
+	DefaultErr = CreateOptions["defaultError"] extends StandardSchemaV1
+		? StandardSchemaV1.InferOutput<CreateOptions["defaultError"]>
 		: unknown,
 	S extends MergeSchema<CreateOptions> = MergeSchema<CreateOptions>,
 > = <
@@ -179,11 +183,11 @@ export type BetterFetch<
 		InferPluginOptions<CreateOptions>
 	>,
 	Result = BetterFetchResponse<
-		O["output"] extends ZodSchema
-			? z.infer<O["output"]>
+		O["output"] extends StandardSchemaV1
+			? StandardSchemaV1.InferOutput<O["output"]>
 			: F extends FetchSchema
-				? F["output"] extends ZodSchema
-					? z.infer<F["output"]>
+				? F["output"] extends StandardSchemaV1
+					? StandardSchemaV1.InferOutput<F["output"]>
 					: Res
 				: Res,
 		Err,

--- a/packages/better-fetch/src/create-fetch/types.ts
+++ b/packages/better-fetch/src/create-fetch/types.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { StandardSchemaV1 } from "../standard-schema";
 import { IsEmptyObject } from "type-fest";
 import { BetterFetchPlugin } from "../plugins";
 import type { Prettify, StringLiteralUnion } from "../type-utils";

--- a/packages/better-fetch/src/fetch.ts
+++ b/packages/better-fetch/src/fetch.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { StandardSchemaV1 } from "./standard-schema";
 import { BetterFetchError } from "./error";
 import { initializePlugins } from "./plugins";
 import { createRetryStrategy } from "./retry";

--- a/packages/better-fetch/src/plugins.ts
+++ b/packages/better-fetch/src/plugins.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { StandardSchemaV1 } from "./standard-schema";
 import { Schema } from "./create-fetch";
 import { BetterFetchError } from "./error";
 import type { BetterFetchOption } from "./types";

--- a/packages/better-fetch/src/plugins.ts
+++ b/packages/better-fetch/src/plugins.ts
@@ -1,7 +1,7 @@
-import type { ZodSchema } from "zod";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { Schema } from "./create-fetch";
-import type { BetterFetchOption } from "./types";
 import { BetterFetchError } from "./error";
+import type { BetterFetchOption } from "./types";
 
 export type RequestContext<T extends Record<string, any> = any> = {
 	url: URL;
@@ -128,7 +128,7 @@ export type BetterFetchPlugin = {
 	/**
 	 * Additional options that can be passed to the plugin
 	 */
-	getOptions?: () => ZodSchema;
+	getOptions?: () => StandardSchemaV1;
 };
 
 export const initializePlugins = async (

--- a/packages/better-fetch/src/standard-schema.ts
+++ b/packages/better-fetch/src/standard-schema.ts
@@ -1,0 +1,70 @@
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+	/** The Standard Schema properties. */
+	readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+	/** The Standard Schema properties interface. */
+	export interface Props<Input = unknown, Output = Input> {
+		/** The version number of the standard. */
+		readonly version: 1;
+		/** The vendor name of the schema library. */
+		readonly vendor: string;
+		/** Validates unknown input values. */
+		readonly validate: (
+			value: unknown,
+		) => Result<Output> | Promise<Result<Output>>;
+		/** Inferred types associated with the schema. */
+		readonly types?: Types<Input, Output> | undefined;
+	}
+
+	/** The result interface of the validate function. */
+	export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+	/** The result interface if validation succeeds. */
+	export interface SuccessResult<Output> {
+		/** The typed output value. */
+		readonly value: Output;
+		/** The non-existent issues. */
+		readonly issues?: undefined;
+	}
+
+	/** The result interface if validation fails. */
+	export interface FailureResult {
+		/** The issues of failed validation. */
+		readonly issues: ReadonlyArray<Issue>;
+	}
+
+	/** The issue interface of the failure output. */
+	export interface Issue {
+		/** The error message of the issue. */
+		readonly message: string;
+		/** The path of the issue, if any. */
+		readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+	}
+
+	/** The path segment interface of the issue. */
+	export interface PathSegment {
+		/** The key representing a path segment. */
+		readonly key: PropertyKey;
+	}
+
+	/** The Standard Schema types interface. */
+	export interface Types<Input = unknown, Output = Input> {
+		/** The input type of the schema. */
+		readonly input: Input;
+		/** The output type of the schema. */
+		readonly output: Output;
+	}
+
+	/** Infers the input type of a Standard Schema. */
+	export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+		Schema["~standard"]["types"]
+	>["input"];
+
+	/** Infers the output type of a Standard Schema. */
+	export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+		Schema["~standard"]["types"]
+	>["output"];
+}

--- a/packages/better-fetch/src/test/create.test.ts
+++ b/packages/better-fetch/src/test/create.test.ts
@@ -19,8 +19,8 @@ import {
 import type { BetterFetchResponse } from "../types";
 
 import { BetterFetchPlugin } from "../plugins";
+import { ValidationError } from "../utils";
 import { router } from "./test-router";
-import { ValidationError } from '../utils';
 
 const schema = {
 	"/": {

--- a/packages/better-fetch/src/test/create.test.ts
+++ b/packages/better-fetch/src/test/create.test.ts
@@ -8,7 +8,7 @@ import {
 	expectTypeOf,
 	it,
 } from "vitest";
-import { ZodError, z } from "zod";
+import { z } from "zod";
 import {
 	BetterFetch,
 	type FetchSchemaRoutes,
@@ -20,6 +20,7 @@ import type { BetterFetchResponse } from "../types";
 
 import { BetterFetchPlugin } from "../plugins";
 import { router } from "./test-router";
+import { ValidationError } from '../utils';
 
 const schema = {
 	"/": {
@@ -137,7 +138,7 @@ describe("create-fetch-runtime-test", () => {
 				return new Response();
 			},
 		});
-		expect(f("/post")).rejects.toThrowError(ZodError);
+		expect(f("/post")).rejects.toThrowError(ValidationError);
 	});
 
 	it("should parse params and other inputs", async () => {

--- a/packages/better-fetch/src/test/fetch.test.ts
+++ b/packages/better-fetch/src/test/fetch.test.ts
@@ -2,8 +2,8 @@ import { createApp, toNodeListener } from "h3";
 import { type Listener, listen } from "listhen";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { BetterFetchError, betterFetch, createFetch } from "..";
-import { router } from "./test-router";
 import { getURL } from "../url";
+import { router } from "./test-router";
 
 describe("fetch", () => {
 	const getURL = (path?: string) =>
@@ -320,7 +320,7 @@ describe("hooks", () => {
 		expect(onError).toHaveBeenCalledWith({
 			request: expect.any(Object),
 			response: expect.any(Response),
-			responseText: "{\"message\":\"Server Error\"}",
+			responseText: '{"message":"Server Error"}',
 			error: {
 				message: "Server Error",
 				status: 500,

--- a/packages/better-fetch/src/types.ts
+++ b/packages/better-fetch/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema } from "zod";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Auth } from "./auth";
 import type { BetterFetchPlugin, FetchHooks } from "./plugins";
 import type { RetryOptions } from "./retry";
@@ -122,14 +122,14 @@ export type BetterFetchOption<
 			 * });
 			 * ```
 			 */
-			output?: ZodSchema | typeof Blob | typeof File;
+			output?: StandardSchemaV1 | typeof Blob | typeof File;
 			/**
 			 * Additional error schema for the error object if the
 			 * response fails.
 			 */
-			errorSchema?: ZodSchema;
+			errorSchema?: StandardSchemaV1;
 			/**
-			 * Disable zod validation for the response
+			 * Disable validation for the response
 			 * @default false
 			 */
 			disableValidation?: boolean;

--- a/packages/better-fetch/src/types.ts
+++ b/packages/better-fetch/src/types.ts
@@ -1,7 +1,7 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Auth } from "./auth";
 import type { BetterFetchPlugin, FetchHooks } from "./plugins";
 import type { RetryOptions } from "./retry";
+import { StandardSchemaV1 } from "./standard-schema";
 import type { Prettify, StringLiteralUnion } from "./type-utils";
 
 type CommonHeaders = {

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -249,16 +249,16 @@ export function bodyParser(data: any, responseType: ResponseType) {
 }
 
 export class ValidationError extends Error {
-  public readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+	public readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
 
-  constructor(issues: ReadonlyArray<StandardSchemaV1.Issue>, message?: string) {
-    // Default message fallback in case one isn't supplied.
-    super(message || JSON.stringify(issues, null, 2));
-    this.issues = issues;
-    
-    // Set the prototype explicitly to ensure that instanceof works correctly.
-    Object.setPrototypeOf(this, ValidationError.prototype);
-  }
+	constructor(issues: ReadonlyArray<StandardSchemaV1.Issue>, message?: string) {
+		// Default message fallback in case one isn't supplied.
+		super(message || JSON.stringify(issues, null, 2));
+		this.issues = issues;
+
+		// Set the prototype explicitly to ensure that instanceof works correctly.
+		Object.setPrototypeOf(this, ValidationError.prototype);
+	}
 }
 
 export async function parseStandardSchema<TSchema extends StandardSchemaV1>(
@@ -268,8 +268,7 @@ export async function parseStandardSchema<TSchema extends StandardSchemaV1>(
 	let result = await schema["~standard"].validate(input);
 
 	if (result.issues) {
-		throw new ValidationError(result.issues)
+		throw new ValidationError(result.issues);
 	}
 	return result.value;
 }
-

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { getAuthHeader } from "./auth";
 import { methods } from "./create-fetch";
 import type { BetterFetchOption, FetchEsque } from "./types";
@@ -246,3 +247,29 @@ export function bodyParser(data: any, responseType: ResponseType) {
 	}
 	return data;
 }
+
+export class ValidationError extends Error {
+  public readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+
+  constructor(issues: ReadonlyArray<StandardSchemaV1.Issue>, message?: string) {
+    // Default message fallback in case one isn't supplied.
+    super(message || JSON.stringify(issues, null, 2));
+    this.issues = issues;
+    
+    // Set the prototype explicitly to ensure that instanceof works correctly.
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}
+
+export async function parseStandardSchema<TSchema extends StandardSchemaV1>(
+	schema: TSchema,
+	input: StandardSchemaV1.InferInput<TSchema>,
+): Promise<StandardSchemaV1.InferOutput<TSchema>> {
+	let result = await schema["~standard"].validate(input);
+
+	if (result.issues) {
+		throw new ValidationError(result.issues)
+	}
+	return result.value;
+}
+

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { StandardSchemaV1 } from "./standard-schema";
 import { getAuthHeader } from "./auth";
 import { methods } from "./create-fetch";
 import type { BetterFetchOption, FetchEsque } from "./types";

--- a/packages/better-fetch/tsconfig.json
+++ b/packages/better-fetch/tsconfig.json
@@ -1,13 +1,14 @@
 {
 	"compilerOptions": {
 		"target": "ES2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-		"module": "commonjs" /* Specify what module code is generated. */,
+		"module": "ES2015" /* Specify what module code is generated. */,
 		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
 		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 		"strict": true /* Enable all strict type-checking options. */,
 		"noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
-		"noEmit": true
+		"noEmit": true,
+		"moduleResolution": "bundler", /// https://github.com/colinhacks/zod/issues/3739
 	},
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/better-fetch/tsconfig.json
+++ b/packages/better-fetch/tsconfig.json
@@ -8,7 +8,7 @@
 		"noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
 		"noEmit": true,
-		"moduleResolution": "bundler", /// https://github.com/colinhacks/zod/issues/3739
+		"moduleResolution": "bundler" /// https://github.com/colinhacks/zod/issues/3739
 	},
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,7 +13,7 @@
 		"@better-fetch/fetch": "workspace:*",
 		"tsx": "^4.16.2",
 		"typescript": "^5.5.3",
-		"zod": "^3.23.8"
+		"zod": "^3.24.0"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,8 +12,7 @@
 	"devDependencies": {
 		"@better-fetch/fetch": "workspace:*",
 		"tsx": "^4.16.2",
-		"typescript": "^5.5.3",
-		"zod": "^3.24.0"
+		"typescript": "^5.5.3"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/logger/tsup.config.ts
+++ b/packages/logger/tsup.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
 	format: ["cjs", "esm"],
 	dts: true,
 	clean: true,
-	external: ["zod"],
+	external: [],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,10 +130,6 @@ importers:
         version: 5.6.2
 
   packages/better-fetch:
-    dependencies:
-      '@standard-schema/spec':
-        specifier: ^1.0.0
-        version: 1.0.0
     devDependencies:
       '@happy-dom/global-registrator':
         specifier: ^14.7.1
@@ -181,7 +177,7 @@ importers:
         specifier: ^1.5.0
         version: 1.6.0(@types/node@20.14.10)(happy-dom@14.12.3)(jsdom@24.1.3)
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.24.1
         version: 3.24.1
 
   packages/logger:
@@ -1359,9 +1355,6 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -4649,8 +4642,6 @@ snapshots:
   '@shikijs/vscode-textmate@9.2.2': {}
 
   '@sinclair/typebox@0.27.8': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@swc/counter@0.1.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,12 +37,12 @@ importers:
         specifier: ^5.0.0
         version: 5.6.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.24.0
+        version: 3.24.1
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.1.13
+        version: 1.2.2
 
   doc:
     dependencies:
@@ -101,8 +101,8 @@ importers:
         specifier: ^2.4.0
         version: 2.5.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.24.0
+        version: 3.24.1
     devDependencies:
       '@types/mdx':
         specifier: ^2.0.13
@@ -130,6 +130,10 @@ importers:
         version: 5.6.2
 
   packages/better-fetch:
+    dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@happy-dom/global-registrator':
         specifier: ^14.7.1
@@ -177,8 +181,8 @@ importers:
         specifier: ^1.5.0
         version: 1.6.0(@types/node@20.14.10)(happy-dom@14.12.3)(jsdom@24.1.3)
       zod:
-        specifier: ^3.23.6
-        version: 3.23.8
+        specifier: ^3.24.0
+        version: 3.24.1
 
   packages/logger:
     dependencies:
@@ -196,8 +200,8 @@ importers:
         specifier: ^5.5.3
         version: 5.6.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.24.0
+        version: 3.24.1
 
 packages:
 
@@ -1365,6 +1369,9 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -1400,8 +1407,8 @@ packages:
   '@types/bun@1.1.10':
     resolution: {integrity: sha512-76KYVSwrHwr9zsnk6oLXOGs9KvyBg3U066GLO4rk6JZk1ypEPGCUDZ5yOiESyIHWs9cx9iC8r01utYN32XdmgA==}
 
-  '@types/bun@1.1.13':
-    resolution: {integrity: sha512-KmQxSBgVWCl6RSuerlLGZlIWfdxkKqat0nxN61+qu4y1KDn0Ll3j7v1Pl8GnaL3a/U6GGWVTJh75ap62kR1E8Q==}
+  '@types/bun@1.2.2':
+    resolution: {integrity: sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1599,8 +1606,8 @@ packages:
   bun-types@1.1.29:
     resolution: {integrity: sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw==}
 
-  bun-types@1.1.34:
-    resolution: {integrity: sha512-br5QygTEL/TwB4uQOb96Ky22j4Gq2WxWH/8Oqv20fk5HagwKXo/akB+LiYgSfzexCt6kkcUaVm+bKiPl71xPvw==}
+  bun-types@1.2.2:
+    resolution: {integrity: sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg==}
 
   bundle-require@5.0.0:
     resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
@@ -3687,8 +3694,8 @@ packages:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4658,6 +4665,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.5':
@@ -4704,9 +4713,9 @@ snapshots:
     dependencies:
       bun-types: 1.1.29
 
-  '@types/bun@1.1.13':
+  '@types/bun@1.2.2':
     dependencies:
-      bun-types: 1.1.34
+      bun-types: 1.2.2
 
   '@types/debug@4.1.12':
     dependencies:
@@ -4916,9 +4925,9 @@ snapshots:
       '@types/node': 20.12.14
       '@types/ws': 8.5.12
 
-  bun-types@1.1.34:
+  bun-types@1.2.2:
     dependencies:
-      '@types/node': 20.12.14
+      '@types/node': 20.14.10
       '@types/ws': 8.5.12
 
   bundle-require@5.0.0(esbuild@0.23.1):
@@ -5428,7 +5437,7 @@ snapshots:
       hast-util-to-estree: 3.1.0
       npm-to-yarn: 3.0.0
       unist-util-visit: 5.0.0
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5442,7 +5451,7 @@ snapshots:
       fumadocs-core: 12.4.2(@types/react@18.3.8)(next@14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gray-matter: 4.0.3
       next: 14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7483,6 +7492,6 @@ snapshots:
 
   yocto-queue@1.1.1: {}
 
-  zod@3.23.8: {}
+  zod@3.24.1: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,11 +47,11 @@ importers:
   doc:
     dependencies:
       '@better-fetch/fetch':
-        specifier: ^1.1.0
-        version: 1.1.9
+        specifier: workspace:*
+        version: link:../packages/better-fetch
       '@better-fetch/logger':
-        specifier: ^1.1.0
-        version: 1.1.3
+        specifier: workspace:*
+        version: link:../packages/logger
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
@@ -98,7 +98,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       tailwind-merge:
-        specifier: ^2.4.0
+        specifier: ^2.5.2
         version: 2.5.2
       zod:
         specifier: ^3.24.0
@@ -199,9 +199,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.6.2
-      zod:
-        specifier: ^3.24.0
-        version: 3.24.1
 
 packages:
 
@@ -228,12 +225,6 @@ packages:
   '@babel/runtime@7.25.6':
     resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
     engines: {node: '>=6.9.0'}
-
-  '@better-fetch/fetch@1.1.9':
-    resolution: {integrity: sha512-eeWQ4X9eewQgn8RC26oI8oW5DO8WRfD85hFOvOCbtG5UABqEh+vAmBEY7S6r56BTXzOsK+fVH204JTlvacxTew==}
-
-  '@better-fetch/logger@1.1.3':
-    resolution: {integrity: sha512-GuT6bbE+g10eIdUwW5ctOikryAnvb8i/c5HHttKZu1OFygVV82pX8JxyobtZZV9Z8Md03qNEV0PvaUDbBd9sHQ==}
 
   '@biomejs/biome@1.7.3':
     resolution: {integrity: sha512-ogFQI+fpXftr+tiahA6bIXwZ7CSikygASdqMtH07J2cUzrpjyTMVc9Y97v23c7/tL1xCZhM+W9k4hYIBm7Q6cQ==}
@@ -3727,12 +3718,6 @@ snapshots:
   '@babel/runtime@7.25.6':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@better-fetch/fetch@1.1.9': {}
-
-  '@better-fetch/logger@1.1.3':
-    dependencies:
-      consola: 3.2.3
 
   '@biomejs/biome@1.7.3':
     optionalDependencies:


### PR DESCRIPTION
Migrate away from zod to standard schema.

Resolve #18 

Slight breaking change as you will have to use the latest version of zod for standard schema support