### PR TITLE
fix: query params in react native

### DIFF
--- a/packages/better-fetch/src/url.ts
+++ b/packages/better-fetch/src/url.ts
@@ -47,8 +47,9 @@ export function getURL(url: string, option?: BetterFetchOption) {
 
 	path = path.split("/").map(encodeURIComponent).join("/");
 	if (path.startsWith("/")) path = path.slice(1);
-	let queryParamString =
-		queryParams.size > 0 ? `?${queryParams}`.replace(/\+/g, "%20") : "";
+	let queryParamString = queryParams.toString();
+	queryParamString =
+		queryParamString.length > 0 ? `?${queryParamString}`.replace(/\+/g, "%20") : "";
 	if (!basePath.startsWith("http")) {
 		return `${basePath}${path}${queryParamString}`;
 	}


### PR DESCRIPTION
This fix is needed because `queryParams.size` is `undefined` in React Native (at least in 0.76.7).

Without this fix, query options in Better Auth like this don't work for Expo 52, which uses React Native 0.76:
```ts
 // these query options never reach the server without this fix
authClient.admin.listUsers({ query: { sortBy: 'name', sortDirection: 'desc' } })
```