### PR TITLE
fix(auth): ensure getValue is properly awaited

### DIFF
--- a/packages/better-fetch/src/auth.ts
+++ b/packages/better-fetch/src/auth.ts
@@ -59,18 +59,23 @@ export const getAuthHeader = async (options?: BetterFetchOption) => {
 			}
 			headers["authorization"] = `Bearer ${token}`;
 		} else if (options.auth.type === "Basic") {
-			const username = getValue(options.auth.username);
-			const password = getValue(options.auth.password);
+			const [username, password] = await Promise.all([
+				getValue(options.auth.username),
+				getValue(options.auth.password),
+			]);
 			if (!username || !password) {
 				return headers;
 			}
 			headers["authorization"] = `Basic ${btoa(`${username}:${password}`)}`;
 		} else if (options.auth.type === "Custom") {
-			const value = getValue(options.auth.value);
+			const [prefix, value] = await Promise.all([
+				getValue(options.auth.prefix),
+				getValue(options.auth.value),
+			]);
 			if (!value) {
 				return headers;
 			}
-			headers["authorization"] = `${getValue(options.auth.prefix)} ${value}`;
+			headers["authorization"] = `${prefix ?? ""} ${value}`;
 		}
 	}
 	return headers;


### PR DESCRIPTION
Basic auth and custom auth does not work.

Turns out the `getValue` function in `auth.ts` is not awaited. This means that, for example in basic auth, what's being sent is the base64 encoded version of

```
[object Promise]:[object Promise]
```

instead of
```
username:password
```