### PR TITLE
Fix: Typo in Docs (extra-options)

### DIFF
--- a/doc/content/docs/extra-options.mdx
+++ b/doc/content/docs/extra-options.mdx
@@ -3,7 +3,7 @@ title: Extra Options
 description: Fetch Options
 ---
 
-These are better fetch specefic options.
+These are better fetch specific options.
 
 ### Better Fetch Options
 <AutoTypeTable path="./lib/better-fetch-options.ts" name="BetterFetchOptions" />


### PR DESCRIPTION
Typo fix specefic -> specific