### PR TITLE
feat(fetch): pass validation error to hooks 

### DIFF
--- a/doc/content/docs/hooks.mdx
+++ b/doc/content/docs/hooks.mdx
@@ -3,7 +3,7 @@ title: Hooks
 description: Hooks
 ---
 
-Hooks are functions that are called at different stages of the request lifecycle. 
+Hooks are functions that are called at different stages of the request lifecycle.
 
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";
@@ -50,7 +50,7 @@ import { createFetch } from "@better-fetch/fetch";
 
 const $fetch = createFetch({
     baseURL: "http://localhost:3000",
-    onResponse(context) {        
+    onResponse(context) {
         // do something with the context
         return context.response // return the response
     },
@@ -61,6 +61,7 @@ const $fetch = createFetch({
 ## On Success and On Error
 
 on success and on error are callbacks that will be called when a request is successful or when an error occurs. The function will be called with the response context as an argument and it's not expeceted to return anything.
+If schema validation fails, the `onError` hook will be called as well.
 
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";
@@ -72,6 +73,45 @@ const $fetch = createFetch({
     },
     onError(context) {
         // do something with the context
+        // console.log(context.error.type); // "validation" | "http"
     },
 })
+```
+
+### Error Types
+
+The `onError` hook receives different error types depending on what caused the error:
+
+#### HTTP Errors
+When an HTTP request fails (non-2xx status codes), the error context contains:
+
+```ts
+{
+  response: Response,
+  request: RequestContext,
+  error: {
+    type: "http",
+    status: number,
+    statusText: string,
+    // ... other response data
+  },
+  responseText: string
+}
+```
+
+#### Validation Errors
+When schema validation fails on the response data, the error context contains:
+
+```ts
+{
+  response: Response,
+  request: RequestContext,
+  error: {
+    type: "validation",
+    issues: Array<ValidationIssue>,
+    message: string,
+    status: number,
+    statusText: string,
+  }
+}
 ```

--- a/packages/better-fetch/src/fetch.ts
+++ b/packages/better-fetch/src/fetch.ts
@@ -14,6 +14,7 @@ import {
 	isJSONParsable,
 	jsonParse,
 	parseStandardSchema,
+	ValidationError,
 } from "./utils";
 
 export const betterFetch = async <
@@ -129,10 +130,41 @@ export const betterFetch = async <
 		 */
 		if (context?.output) {
 			if (context.output && !context.disableValidation) {
-				successContext.data = await parseStandardSchema(
-					context.output as StandardSchemaV1,
-					successContext.data,
-				);
+				try {
+					successContext.data = await parseStandardSchema(
+						context.output as StandardSchemaV1,
+						successContext.data,
+					);
+				} catch (err) {
+					const validationError = err as ValidationError;
+
+					// Create validation error context for hooks
+					const validationErrorContext = {
+						response,
+						request: context,
+						error: {
+							type: 'validation' as const,
+							issues: validationError.issues,
+							message: validationError.message,
+							status: response.status,
+							statusText: response.statusText,
+						},
+					};
+
+
+					if (options?.onError) {
+						await options.onError(validationErrorContext);
+					}
+
+					// Call all onError hooks with validation error
+					for (const onError of hooks.onError) {
+						if (onError) {
+							await onError(validationErrorContext);
+						}
+					}
+
+					throw validationError;
+				}
 			}
 		}
 
@@ -169,6 +201,7 @@ export const betterFetch = async <
 		request: context,
 		error: {
 			...errorObject,
+			type: 'http' as const,
 			status: response.status,
 			statusText: response.statusText,
 		},

--- a/packages/better-fetch/src/plugins.ts
+++ b/packages/better-fetch/src/plugins.ts
@@ -19,11 +19,27 @@ export type SuccessContext<Res = any> = {
 	response: Response;
 	request: RequestContext;
 };
-export type ErrorContext = {
+export type ValidationErrorContext = {
+	response?: Response;
+	request: RequestContext;
+	error: {
+		type: 'validation';
+		issues: ReadonlyArray<StandardSchemaV1.Issue>;
+		message: string;
+		status?: number;
+		statusText?: string;
+	};
+};
+
+export type HttpErrorContext = {
 	response: Response;
 	request: RequestContext;
-	error: BetterFetchError & Record<string, any>;
+	error: BetterFetchError & Record<string, any> & {
+		type: 'http';
+	};
 };
+
+export type ErrorContext = HttpErrorContext | ValidationErrorContext;
 export interface FetchHooks<Res = any> {
 	/**
 	 * a callback function that will be called when a


### PR DESCRIPTION
Attempt to close #42. 

PR adjusts hooks with validation errors, pass it to the hooks before throw it. To allow distinguish between error types, now error context have `type` property. The existing behavior is preserved if hooks are not provided.