### PR TITLE
Update fetch test file

### DIFF
--- a/packages/better-fetch/src/test/fetch.test.ts
+++ b/packages/better-fetch/src/test/fetch.test.ts
@@ -295,6 +295,38 @@ describe("fetch", () => {
 			authorization: "Bearer test",
 		});
 	});
+
+	it("should set basic auth headers", async () => {
+		const url = getURL("post");
+		await betterFetch<any>(url, {
+			auth: {
+				type: "Basic",
+				username: "test-user",
+				password: "test-password",
+			},
+			onRequest: (req) => {
+				expect(req.headers.get("authorization")).to.equal(
+					"Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=",
+				);
+			},
+		});
+	});
+
+	it("shet set basic auth headers with function for username and password", async () => {
+		const url = getURL("post");
+		await betterFetch<any>(url, {
+			auth: {
+				type: "Basic",
+				username: () => "test-user",
+				password: () => "test-password",
+			},
+			onRequest: (req) => {
+				expect(req.headers.get("authorization")).to.equal(
+					"Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=",
+				);
+			},
+		});
+	});
 });
 
 describe("fetch-error", () => {


### PR DESCRIPTION
I see that there's already a [PR merged](https://github.com/Bekacru/better-fetch/pull/48) that fixes my issue with the basic auth. This just adds some tests around that change. I've reverted to 1.1.17 until those changes are published to a new version.

Thanks for such a great library!