### PR TITLE
fix: pass plugin from options on createFetch

### DIFF
--- a/packages/better-fetch/src/create-fetch/index.ts
+++ b/packages/better-fetch/src/create-fetch/index.ts
@@ -73,7 +73,7 @@ export const createFetch = <Option extends CreateFetchOption>(
 		const opts = {
 			...config,
 			...options,
-			plugins: [...(config?.plugins || []), applySchemaPlugin(config || {})],
+			plugins: [...(config?.plugins || []), applySchemaPlugin(config || {}), ...(options?.plugins || [])],
 		} as BetterFetchOption;
 
 		if (config?.catchAllError) {


### PR DESCRIPTION
This PR fixes an issue where passing a plugin when calling the fetch from an instance that was created by `createFetch` 

```
const client = createFetch()

client('/todo', { plugins: [somePlugin] })
```