### PR TITLE
feat: add support for header validation and aggregation in fetch schema

### DIFF
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,23 +1,37 @@
-import { betterFetch, createFetch, createSchema } from "@better-fetch/fetch";
+import { createFetch, createSchema } from "@better-fetch/fetch";
 import { z } from "zod";
-
+ 
 const $fetch = createFetch({
-	schema: createSchema({
-		"@patch/user": {
-			input: z.object({
-				id: z.string(),
+    baseURL: "https://jsonplaceholder.typicode.com",
+    schema: createSchema({
+        "/path": {
+            input: z.object({
+                userId: z.string(),
+                id: z.number(),
+                title: z.string(),
+                completed: z.boolean(),
+            }),
+			headers: z.object({
+				"x-custom-header": z.string(),
 			}),
-		},
-	}),
-	baseURL: "http://localhost:3000",
-	onRequest(context) {
-		console.log("onRequest", JSON.parse(context.body));
+        },
+    }), 
+	auth: {
+		type: "Bearer",
+		token:"test-token",
+	}
+})
+ 
+const { data, error } = await $fetch("/path", {
+    body: {
+        userId: "1",
+        id: 1,
+        title: "title",
+        completed: true,
+    },
+	headers: {
+		"x-custom-header": "custom-value",
 	},
-});
+})
 
-const f = $fetch("https://jsonplaceholder.typicode.com/todos/:id", {
-	method: "GET",
-	params: {
-		id: "1",
-	},
-});
+console.log(data, error);

--- a/doc/content/docs/authorization.mdx
+++ b/doc/content/docs/authorization.mdx
@@ -6,6 +6,10 @@ description: Authorization
 Authorization is a way that allows you to add authentication headers to the request.
 Currently, supports `Bearer` and `Basic` authorization.
 
+<Callout type="info">
+For more advanced header handling and validation, see the [Headers](/docs/headers) documentation.
+</Callout>
+
 ### Bearer
 
 The bearer authorization is used to add a bearer token to the request. The token is added to the `Authorization` header. 

--- a/doc/content/docs/fetch-schema.mdx
+++ b/doc/content/docs/fetch-schema.mdx
@@ -47,9 +47,13 @@ const $fetch = createFetch({
 ## Fetch Schema
 
 The Fetch Schema is a map of path/url and schema. The path is the url path and the schema is an object with 
-`input`, `output`, `query` and `params` keys.
+`input`, `output`, `query`, `params`, and `headers` keys.
 
-The `input` key is the schema of the request data. The `output` key is the schema of the response data. The `query` key is the schema of the query params. The `params` key is dynamic path parameters.
+The `input` key is the schema of the request data. The `output` key is the schema of the response data. The `query` key is the schema of the query params. The `params` key is dynamic path parameters. The `headers` key is for header validation.
+
+<Callout type="info">
+For detailed information about header validation and types, see the [Headers](/docs/headers) documentation.
+</Callout>
 
 ### Input
 
@@ -142,6 +146,38 @@ const { data, error } = await $fetch("/path", {
 })
 // @annotate: Hover over the data object to see the type
 ```
+
+### Headers
+
+The headers schema is the schema of the request headers. You can define header validation using Zod or any StandardSchema library.
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    baseURL: "http://localhost:3000",
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-api-key": z.string(),
+                "x-user-id": z.string().uuid(),
+            }),
+        },
+    }),
+})
+
+const { data } = await $fetch("/api/users", {
+    headers: {
+        "x-api-key": "my-key",
+        "x-user-id": "123e4567-e89b-12d3-a456-426614174000",
+    },
+})
+```
+
+<Callout type="info">
+Header keys should be defined in lowercase for case-insensitive matching. See [Headers](/docs/headers) for more details.
+</Callout>
 
 ### Dynamic Path Parameters
 

--- a/doc/content/docs/getting-started.mdx
+++ b/doc/content/docs/getting-started.mdx
@@ -100,13 +100,15 @@ Learn more about handling errors [Handling Errors](/docs/handling-errors) sectio
 
 ### Fetch Schema
 
-Fetch schema enables you to pre-define the URL path and the shape of request and response data. This makes it easy to document your API. 
+Fetch schema enables you to pre-define the URL path and the shape of request and response data, including headers, query parameters, and path parameters. This makes it easy to document your API. 
 
 <Callout type="info">
    Plugins can also define fetch schemas. See [Plugins](/docs/plugins) section for more details.
 </Callout>
 
 The output of the schema will be validated using your schema and if the validation fails, it'll throw an error.
+
+You can validate headers, request body, query params, and more. See [Fetch Schema](/docs/fetch-schema) and [Headers](/docs/headers) for more details.
 
 ```ts twoslash title="fetch.ts" 
 import { createSchema, createFetch } from "@better-fetch/fetch";

--- a/doc/content/docs/headers.mdx
+++ b/doc/content/docs/headers.mdx
@@ -1,0 +1,301 @@
+---
+title: Headers
+description: Type-safe headers with validation and aggregation
+---
+{/* has to be migrated to twoslash after better-fetch release */}
+
+Better Fetch provides type-safe headers with validation support using Zod or any StandardSchema library. Headers are properly aggregated from multiple sources and validated at runtime.
+
+## Basic Usage
+
+You can set headers at three different levels: configuration, schema, and request level.
+
+### Configuration Level Headers
+
+Headers set at the configuration level are applied to all requests:
+
+```ts title="fetch.ts"
+import { createFetch } from "@better-fetch/fetch";
+
+const $fetch = createFetch({
+    baseURL: "http://localhost:3000",
+    headers: {
+        "x-api-key": "my-api-key",
+        "x-client-version": "1.0.0",
+    },
+})
+```
+
+### Request Level Headers
+
+Headers can be set on individual requests:
+
+```ts title="fetch.ts"
+import { betterFetch } from "@better-fetch/fetch";
+
+const { data, error } = await betterFetch("http://localhost:3000/api/users", {
+    headers: {
+        "x-request-id": "unique-request-id",
+    },
+})
+```
+
+## Schema-Based Header Validation
+
+You can define header schemas using Zod or any StandardSchema library. This provides runtime validation and type inference.
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    baseURL: "http://localhost:3000",
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-user-id": z.string().uuid(),
+                "x-api-version": z.string().regex(/^\d+\.\d+\.\d+$/),
+            }),
+        },
+    }),
+})
+
+// This will validate headers at runtime
+const { data, error } = await $fetch("/api/users", {
+    headers: {
+        "x-user-id": "123e4567-e89b-12d3-a456-426614174000",
+        "x-api-version": "1.0.0",
+    },
+})
+```
+
+<Callout type="warning">
+Header keys in schemas should be defined in **lowercase** (e.g., `"x-custom-header"`) to ensure case-insensitive matching. However, you can pass headers in any casing when making requests.
+</Callout>
+
+## Header Aggregation
+
+Headers are merged in the following order (later overrides earlier):
+
+1. **Configuration headers** - Set in `createFetch({ headers: ... })`
+2. **Schema headers** - Validated against the schema definition
+3. **Request headers** - Set on individual requests
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    baseURL: "http://localhost:3000",
+    headers: {
+        "x-api-key": "config-key", // Applied to all requests
+    },
+    schema: createSchema({
+        "/api/data": {
+            headers: z.object({
+                "x-tenant-id": z.string(),
+            }),
+        },
+    }),
+})
+
+// Final headers will include: x-api-key, x-tenant-id, and x-request-id
+const { data } = await $fetch("/api/data", {
+    headers: {
+        "x-tenant-id": "tenant-123",
+        "x-request-id": "req-456", // Additional header
+    },
+})
+```
+
+## Case-Insensitive Headers
+
+HTTP headers are case-insensitive by specification. Better Fetch handles this automatically:
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-custom-header": z.string(), // Define in lowercase
+            }),
+        },
+    }),
+})
+
+// All of these will work correctly:
+await $fetch("/api/users", {
+    headers: { "x-custom-header": "value" },
+})
+
+await $fetch("/api/users", {
+    headers: { "X-Custom-Header": "value" },
+})
+
+await $fetch("/api/users", {
+    headers: { "X-CUSTOM-HEADER": "value" },
+})
+```
+
+<Callout type="info">
+Headers are normalized to lowercase internally before validation, ensuring consistent behavior regardless of how they're passed.
+</Callout>
+
+## Validation Errors
+
+When headers don't match the schema, Better Fetch throws a detailed validation error:
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-user-id": z.string().uuid(),
+            }),
+        },
+    }),
+})
+
+try {
+    await $fetch("/api/users", {
+        headers: {
+            "x-user-id": "invalid-uuid", // Will fail validation
+        },
+    })
+} catch (error) {
+    console.error(error.message)
+    // Error: [
+    //   {
+    //     "code": "invalid_string",
+    //     "validation": "uuid",
+    //     "path": ["x-user-id"],
+    //     "message": "Invalid uuid"
+    //   }
+    // ]
+}
+```
+
+## Optional Headers
+
+You can make headers optional in your schema:
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-user-id": z.string(),
+                "x-trace-id": z.string().optional(), // Optional header
+            }),
+        },
+    }),
+})
+
+// This works without x-trace-id
+await $fetch("/api/users", {
+    headers: {
+        "x-user-id": "user-123",
+    },
+})
+```
+
+## Type Safety
+
+Headers defined in schemas provide type inference:
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    schema: createSchema({
+        "/api/users": {
+            headers: z.object({
+                "x-user-id": z.string(),
+                "x-role": z.enum(["admin", "user"]),
+            }),
+        },
+    }),
+})
+
+await $fetch("/api/users", {
+    headers: {
+        "x-user-id": "123",
+        "x-role": "admin", // TypeScript knows the valid values
+    },
+})
+```
+
+## Common Patterns
+
+### API Key Authentication
+
+```ts title="fetch.ts"
+import { createFetch } from "@better-fetch/fetch";
+
+const $fetch = createFetch({
+    baseURL: "https://api.example.com",
+    headers: {
+        "x-api-key": process.env.API_KEY || "",
+    },
+})
+```
+
+### Version Headers
+
+```ts title="fetch.ts"
+import { createFetch, createSchema } from "@better-fetch/fetch";
+import { z } from "zod";
+
+const $fetch = createFetch({
+    baseURL: "https://api.example.com",
+    headers: {
+        "x-api-version": "2024-01-01",
+    },
+    schema: createSchema({
+        "/api/v2/users": {
+            headers: z.object({
+                "x-client-version": z.string(),
+            }),
+        },
+    }),
+})
+```
+
+### Request Tracing
+
+```ts title="fetch.ts"
+import { createFetch } from "@better-fetch/fetch";
+import { v4 as uuidv4 } from "uuid";
+
+const $fetch = createFetch({
+    baseURL: "https://api.example.com",
+    onRequest(context) {
+        if (!context.headers.has("x-request-id")) {
+            context.headers.set("x-request-id", uuidv4());
+        }
+    },
+})
+```
+
+## Best Practices
+
+1. **Use lowercase for schema keys**: Define header names in lowercase in your schemas for consistent case-insensitive matching.
+
+2. **Validate security headers**: Use schemas to ensure security-critical headers are always present and valid.
+
+3. **Global vs Request headers**: Put common headers (API keys, versions) in configuration, request-specific headers (trace IDs) in individual requests.
+
+4. **Type inference**: Leverage TypeScript's type inference from Zod schemas for better developer experience.
+
+5. **Error handling**: Always handle validation errors gracefully, especially for user-provided header values.
+

--- a/doc/content/docs/hooks.mdx
+++ b/doc/content/docs/hooks.mdx
@@ -28,17 +28,24 @@ const $fetch = createFetch({
 
 a callback function that will be called when a request is about to be made. The function will be called with the request context as an argument and it's expected to return the modified request context.
 
+You can use this hook to modify headers, add authentication, or log requests.
+
 ```ts twoslash title="fetch.ts"
 import { createFetch } from "@better-fetch/fetch";
 
 const $fetch = createFetch({
     baseURL: "http://localhost:3000",
     onRequest(context) {
-        // do something with the context
+        // Add or modify headers
+        context.headers.set("x-request-time", new Date().toISOString());
         return context;
     },
 })
 ```
+
+<Callout type="info">
+For type-safe header validation, see the [Headers](/docs/headers) documentation.
+</Callout>
 
 ## On Response
 

--- a/doc/content/docs/meta.json
+++ b/doc/content/docs/meta.json
@@ -8,6 +8,7 @@
 		"handling-errors",
 		"---Helpers---",
 		"authorization",
+		"headers",
 		"dynamic-parameters",
 		"timeout-and-retry",
 		"---Advanced---",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
 	"devDependencies": {
 		"bumpp": "^9.4.1",
 		"tsup": "^8.0.2"
-	}
+	},
+	"packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67"
 }

--- a/packages/better-fetch/src/create-fetch/schema.ts
+++ b/packages/better-fetch/src/create-fetch/schema.ts
@@ -7,6 +7,7 @@ export type FetchSchema = {
 	query?: StandardSchemaV1;
 	params?: StandardSchemaV1<Record<string, unknown>> | undefined;
 	method?: Methods;
+	headers?: StandardSchemaV1<Record<string, unknown>>;
 };
 
 export type Methods = "get" | "post" | "put" | "patch" | "delete";

--- a/packages/better-fetch/src/types.ts
+++ b/packages/better-fetch/src/types.ts
@@ -5,15 +5,21 @@ import { StandardSchemaV1 } from "./standard-schema";
 import type { Prettify, StringLiteralUnion } from "./type-utils";
 
 type CommonHeaders = {
-	accept: "application/json" | "text/plain" | "application/octet-stream";
-	"content-type":
+	accept?: StringLiteralUnion<"application/json" | "text/plain" | "application/octet-stream">;
+	"content-type"?: StringLiteralUnion<
 		| "application/json"
 		| "text/plain"
 		| "application/x-www-form-urlencoded"
 		| "multipart/form-data"
-		| "application/octet-stream";
-	authorization: "Bearer" | "Basic";
+		| "application/octet-stream"
+	>;
+	authorization?: StringLiteralUnion<`Bearer ${string}` | `Basic ${string}`>;
 };
+
+export type CustomHeaders<T extends Record<string, string> = {}> = Prettify<
+	CommonHeaders & T & Record<string, string | undefined>
+>;
+
 export type FetchEsque = (
 	input: string | URL | globalThis.Request,
 	init?: RequestInit,
@@ -29,9 +35,10 @@ export type BetterFetchOption<
 	Params extends Record<string, any> | Array<string> | undefined = any,
 	Res = any,
 	ExtraOptions extends Record<string, any> = {},
+	Headers extends Record<string, string> = {},
 > = Prettify<
 	ExtraOptions &
-		Omit<RequestInit, "body"> &
+		Omit<RequestInit, "body" | "headers"> &
 		FetchHooks<Res> & {
 			/**
 			 * a timeout that will be used to abort the
@@ -68,7 +75,7 @@ export type BetterFetchOption<
 			/**
 			 * Headers
 			 */
-			headers?: CommonHeaders | Headers | HeadersInit;
+			headers?: CustomHeaders<Headers> | Headers;
 			/**
 			 * Body
 			 */


### PR DESCRIPTION
## add type-safe headers with schema validation

this PR adds support for type-safe header validation and proper header aggregation across different configuration levels

### features

- **schema-based header validation**: define header schemas using zod or any StandardSchema library
  ```typescript
  schema: createSchema({
    "/api/users": {
      headers: z.object({
        "x-user-id": z.string().uuid(),
      }),
    },
  })
  ```

- **header aggregation**: headers are now properly merged from config -> schema -> request level, with later values overriding earlier ones

- **case-insensitive matching**: headers are normalized to lowercase before validation, following HTTP specification

- **type inference**: typescript automatically infers header types from your schemas

### fixes

- headers weren't being properly aggregated when set at multiple levels
- no validation support for headers in schemas
- type safety was missing for header objects

### documentation

- added headers page
- cross-referenced in Authorization, Fetch Schema, Hooks, and Getting Started pages