### PR TITLE
fix: add body stringification for application/json content-type

### DIFF
--- a/packages/better-fetch/src/test/fetch.test.ts
+++ b/packages/better-fetch/src/test/fetch.test.ts
@@ -114,6 +114,18 @@ describe("fetch", () => {
 		expect(data?.body).to.deep.eq(message);
 	});
 
+	it("stringifies body when content-type is explicitly application/json", async () => {
+		const payload = { foo: "bar" };
+		const { data } = await $echo<any>("/echo", {
+			method: "POST",
+			body: payload,
+			headers: { "Content-Type": "application/json" },
+		});
+
+		expect(data?.body).toEqual(payload);
+		expect(data?.headers).to.include({ "content-type": "application/json" });
+	});
+
 	it("Bypass URLSearchParams body", async () => {
 		const data = new URLSearchParams({ foo: "bar" });
 		const { data: res } = await betterFetch<any>(getURL("post"), {

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -197,7 +197,12 @@ export function getBody(options?: BetterFetchOption) {
 		return null;
 	}
 	const headers = new Headers(options?.headers);
-	if (isJSONSerializable(options.body) && !headers.has("content-type")) {
+	const contentType = headers.get("content-type");
+	const isJSONContentType = contentType && JSON_RE.test(contentType);
+	if (
+		isJSONSerializable(options.body) &&
+		(!headers.has("content-type") || isJSONContentType)
+	) {
 		for (const [key, value] of Object.entries(options?.body)) {
 			if (value instanceof Date) {
 				options.body[key] = value.toISOString();


### PR DESCRIPTION
## Overview

When `Content-Type: application/json` is explicitly specified, automatically apply `JSON.stringify` to the object `body` to resolve the issue where `[object Object]` is sent.
For non-JSON Content-Types, existing behavior is preserved.

## Background / Issue

issue: https://github.com/better-auth/better-fetch/issues/76
In the current implementation, even when `application/json` is specified, an object body is not serialized and is instead sent as `[object Object]`.

## Key Changes

When the header includes `"content-type": "application/json"`, `JSON.stringify` is applied.

## Expected Behavior

For requests that specify `application/json`, payloads such as `{ "foo": "bar" }` are correctly sent as a JSON string.
