### PR TITLE
fix: ci pnpm version mismatch and undefined headers in getBody

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          corepack: true
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
       - main
   merge_group: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   ci:
     name: Build, Typecheck & Test
@@ -26,18 +22,6 @@ jobs:
         with:
           node-version: 20
           corepack: true
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,35 +2,45 @@ name: CI
 
 on:
   pull_request:
-      branches:
-        - main
+    branches:
+      - main
   push:
-      branches:
-        - main
+    branches:
+      - main
   merge_group: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
-  test:
-    name: test & typecheck
+  ci:
+    name: Build, Typecheck & Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          version: 9
-          run_install: false
-
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          corepack: true
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -105,17 +105,12 @@ export async function getHeaders(opts?: BetterFetchOption) {
 	const headers = new Headers();
 	
 	if (opts?.headers) {
-		if (opts.headers instanceof Headers) {
-			opts.headers.forEach((value, key) => {
-				headers.set(key, value);
-			});
-		} else {
-			for (const [key, value] of Object.entries(opts.headers)) {
-				if (value !== null && value !== undefined) {
-					headers.set(key, value);
-				}
-			}
-		}
+		const source = opts.headers instanceof Headers
+			? opts.headers
+			: new Headers(opts.headers as HeadersInit);
+		source.forEach((value, key) => {
+			headers.set(key, value);
+		});
 	}
 	
 	const authHeader = await getAuthHeader(opts);
@@ -213,14 +208,9 @@ export function getBody(options?: BetterFetchOption) {
 		return null;
 	}
 
-	let headers: Headers | null = null;
-	if (options?.headers) {
-		if (options.headers instanceof Headers) {
-			headers = options.headers;
-		} else if (typeof options.headers === "object") {
-			headers = new Headers(options.headers as Record<string, string>);
-		}
-	}
+	const headers = options?.headers
+		? new Headers(options.headers as HeadersInit)
+		: null;
 
 	const hasContentType = headers?.has("content-type") ?? false;
 

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -209,12 +209,12 @@ export function detectContentType(body: any) {
 }
 
 export function getBody(options?: BetterFetchOption) {
-	if (options === null || options === undefined || options.body === null || options.body === undefined) {
+	if (!options?.body) {
 		return null;
 	}
 
 	let headers: Headers | null = null;
-	if (options.headers !== null && options.headers !== undefined) {
+	if (options?.headers) {
 		if (options.headers instanceof Headers) {
 			headers = options.headers;
 		} else if (typeof options.headers === "object") {
@@ -222,10 +222,10 @@ export function getBody(options?: BetterFetchOption) {
 		}
 	}
 
-	const hasContentType = headers !== null && headers.has("content-type");
+	const hasContentType = headers?.has("content-type") ?? false;
 
 	if (isJSONSerializable(options.body) && !hasContentType) {
-		for (const [key, value] of Object.entries(options.body)) {
+		for (const [key, value] of Object.entries(options?.body)) {
 			if (value instanceof Date) {
 				options.body[key] = value.toISOString();
 			}
@@ -233,11 +233,7 @@ export function getBody(options?: BetterFetchOption) {
 		return JSON.stringify(options.body);
 	}
 
-	if (
-		headers !== null &&
-		headers.has("content-type") &&
-		headers.get("content-type") === "application/x-www-form-urlencoded"
-	) {
+	if (headers?.get("content-type") === "application/x-www-form-urlencoded") {
 		if (isJSONSerializable(options.body)) {
 			return new URLSearchParams(options.body).toString();
 		}

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -209,23 +209,23 @@ export function detectContentType(body: any) {
 }
 
 export function getBody(options?: BetterFetchOption) {
-	if (!options?.body) {
+	if (options === null || options === undefined || options.body === null || options.body === undefined) {
 		return null;
 	}
-	
-	let hasContentType = false;
-	if (options?.headers) {
+
+	let headers: Headers | null = null;
+	if (options.headers !== null && options.headers !== undefined) {
 		if (options.headers instanceof Headers) {
-			hasContentType = options.headers.has("content-type");
+			headers = options.headers;
 		} else if (typeof options.headers === "object") {
-			hasContentType = "content-type" in options.headers && 
-				options.headers["content-type"] !== null && 
-				options.headers["content-type"] !== undefined;
+			headers = new Headers(options.headers as Record<string, string>);
 		}
 	}
-	
+
+	const hasContentType = headers !== null && headers.has("content-type");
+
 	if (isJSONSerializable(options.body) && !hasContentType) {
-		for (const [key, value] of Object.entries(options?.body)) {
+		for (const [key, value] of Object.entries(options.body)) {
 			if (value instanceof Date) {
 				options.body[key] = value.toISOString();
 			}
@@ -234,6 +234,7 @@ export function getBody(options?: BetterFetchOption) {
 	}
 
 	if (
+		headers !== null &&
 		headers.has("content-type") &&
 		headers.get("content-type") === "application/x-www-form-urlencoded"
 	) {


### PR DESCRIPTION
hey! noticed ci was failing because `pnpm/action-setup` was set to version 9 but `package.json` has `packageManager` set to pnpm 10.15.1.

removed the hardcoded version from the action so it reads from `package.json` directly.

also fixed a couple of bugs in `utils.ts`:
- `headers` variable was undefined in `getBody`
- `getHeaders` was using `Object.entries` on headers which breaks array-style headers like `[["X-header", "1"]]`