### PR TITLE
fix: support + in JSON content-type suffix regex

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Better Fetch Documentation
 
-A documentation site for [better-fetch](https://github.com/bekacru/better-fetch).
+A documentation site for [better-fetch](https://github.com/better-auth/better-fetch).
 
 ## Development
 

--- a/doc/app/layout.config.tsx
+++ b/doc/app/layout.config.tsx
@@ -22,7 +22,7 @@ export const docsOptions: DocsLayoutProps = {
 	sidebar: {
 		collapsible: false,
 		footer: (
-			<Link href="https://github.com/bekacru/better-fetch" target="_blank">
+			<Link href="https://github.com/better-auth/better-fetch" target="_blank">
 				<GitHubLogoIcon width={16} height={16} />
 			</Link>
 		),

--- a/doc/app/page.tsx
+++ b/doc/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
 							Docs
 						</Button>
 					</Link>
-					<Link href="https://github.com/bekacru/better-fetch">
+					<Link href="https://github.com/better-auth/better-fetch">
 						<Button className="flex gap-2" variant="secondary">
 							<Icons.github />
 							Github

--- a/doc/content/docs/handling-errors.mdx
+++ b/doc/content/docs/handling-errors.mdx
@@ -4,7 +4,7 @@ description: Handling Errors
 ---
 
 ## Default Error Type
-Better fetch by default returns response errors as a value. By defaullt, the error object has 3 properties `status`, `statusText` and `message` properties.
+Better fetch by default returns response errors as a value. By default, the error object has 3 properties `status`, `statusText` and `message` properties.
 
 `status` and `statusText` are always defined. If the api returns a json error object it will be parsed and returned with the error object. By default `error` includes `message` property that can be string or undefined.
 

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -3,7 +3,7 @@ import { getAuthHeader } from "./auth";
 import { methods } from "./create-fetch";
 import type { BetterFetchOption, FetchEsque } from "./types";
 
-const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
+const JSON_RE = /^application\/(?:[\w!#$%&*.^`~+-]*\+)?json(;.+)?$/i;
 
 export type ResponseType = "json" | "text" | "blob";
 export function detectResponseType(request: Response): ResponseType {


### PR DESCRIPTION
related https://github.com/better-auth/better-auth/issues/7953

Handles content types such as `application/did+ld+json` ([src](https://www.w3.org/TR/did-1.0/#application-did-ld-json)).

### Regex Change
- [before](https://regexper.com/#%2F%5Eapplication%5C%2F%28%3F%3A%5B%5Cw!%23%24%25%26*.%5E%60~%2B-%5D*%5C%2B%29%3Fjson%28%3B.%2B%29%3F%24%2Fi)
- [after](https://regexper.com/#%2F%5Eapplication%5C%2F%28%3F%3A%5B%5Cw!%23%24%25%26*.%5E%60~%2B-%5D*%5C%2B%29%3Fjson%28%3B.%2B%29%3F%24%2Fi)

<img width="687" height="462" alt="image" src="https://github.com/user-attachments/assets/c3e22e31-4f4b-40d7-bf4b-438c424db4f2" />
