### PR TITLE
fix: support exactOptionalPropertyTypes and narrow duplex type

### DIFF
--- a/packages/better-fetch/src/create-fetch/index.ts
+++ b/packages/better-fetch/src/create-fetch/index.ts
@@ -95,9 +95,9 @@ export const applySchemaPlugin = (config: CreateFetchOption) =>
 					
 					let opts = {
 						...options,
-						method: keySchema.method,
-						output: keySchema.output,
-						headers: validatedHeaders,
+						...(keySchema.method != null ? { method: keySchema.method } : undefined),
+						...(keySchema.output != null ? { output: keySchema.output } : undefined),
+						...(validatedHeaders != null ? { headers: validatedHeaders } : undefined),
 					};
 					
 					if (!options?.disableValidation) {
@@ -122,7 +122,7 @@ export const applySchemaPlugin = (config: CreateFetchOption) =>
 			}
 			return {
 				url,
-				options,
+				...(options != null ? { options } : undefined),
 			};
 		},
 	}) satisfies BetterFetchPlugin;

--- a/packages/better-fetch/src/types.ts
+++ b/packages/better-fetch/src/types.ts
@@ -93,7 +93,7 @@ export type BetterFetchOption<
 			/**
 			 * Duplex mode
 			 */
-			duplex?: "full" | "half";
+			duplex?: "half";
 			/**
 			 * Custom JSON parser
 			 */

--- a/packages/better-fetch/tsconfig.json
+++ b/packages/better-fetch/tsconfig.json
@@ -5,6 +5,7 @@
 		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
 		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 		"strict": true /* Enable all strict type-checking options. */,
+		"exactOptionalPropertyTypes": true,
 		"noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
 		"noEmit": true,


### PR DESCRIPTION
## Summary

- Enable `exactOptionalPropertyTypes: true` in tsconfig so emitted `.d.ts` files don't expand optional properties with `| undefined`
- Fix code patterns in `create-fetch/index.ts` that assign possibly-undefined values to optional properties
- Narrow `duplex` type from `"full" | "half"` to `"half"` per [WHATWG Fetch spec](https://fetch.spec.whatwg.org/#enumdef-requestduplex)

Closes #86

## Problem

The `Prettify<T>` mapped type causes tsup to emit `| undefined` on all optional properties in the inline-expanded generic default, while the constraint stays as an alias reference. With `exactOptionalPropertyTypes: true`, the expanded default doesn't satisfy its own constraint, producing TS2344 on `betterFetch`.

## Changes

### 1. `tsconfig.json` — enable flag
```diff
 "strict": true,
+"exactOptionalPropertyTypes": true,
```

### 2. `src/create-fetch/index.ts` — conditional spreads
With `exactOptionalPropertyTypes`, assigning `undefined` to an optional property is an error. Four places need conditional spread:

```diff
 let opts = {
   ...options,
-  method: keySchema.method,
-  output: keySchema.output,
-  headers: validatedHeaders,
+  ...(keySchema.method != null ? { method: keySchema.method } : undefined),
+  ...(keySchema.output != null ? { output: keySchema.output } : undefined),
+  ...(validatedHeaders != null ? { headers: validatedHeaders } : undefined),
 };
```

```diff
 return {
   url,
-  options,
+  ...(options != null ? { options } : undefined),
 };
```

### 3. `src/types.ts` — narrow duplex
```diff
-duplex?: "full" | "half";
+duplex?: "half";
```

The WHATWG Fetch spec IDL enum only defines `"half"`. Full-duplex was discussed but never standardized.

## Verification

Verified on v1.1.21 (current npm release, which builds cleanly):

| Gate | Result |
|------|--------|
| `tsc --noEmit` | 0 errors |
| `pnpm build` (tsup) | ESM, CJS, DTS all pass |
| DTS inspection (no `\| undefined` in BetterFetchOption) | Clean |
| Consumer test (`exactOptionalPropertyTypes` + `skipLibCheck: false`) | 0 errors (only pre-existing `Timer` type leak remains) |

## Note on CI

CI will fail due to a pre-existing build breakage on `main` — undefined `headers` variable in `utils.ts` (introduced in #65, tracked in #85, fix in #81). This PR does not touch `utils.ts`.
