### PR TITLE
fix: make emitted .d.ts self-contained for non-DOM environments

### DIFF
--- a/packages/better-fetch/tsup.config.ts
+++ b/packages/better-fetch/tsup.config.ts
@@ -1,11 +1,138 @@
 import { defineConfig } from "tsup";
 
+/**
+ * Fetch API type stubs prepended to built .d.ts files.
+ *
+ * The built .d.ts references Fetch API types (Response, Headers, RequestInit, etc.)
+ * as bare identifiers from lib.dom.d.ts. Consumers whose tsconfig does not include
+ * "DOM" in lib (e.g., backend projects with lib: ["ESNext"]) get TS2304 errors.
+ *
+ * These module-scoped declarations shadow DOM globals when DOM is present and provide
+ * the necessary types when it's absent. Since .d.ts files with export statements are
+ * modules, these declarations are file-scoped and do not pollute the global namespace.
+ */
+const FETCH_API_STUBS = `// -- Fetch API type stubs (self-contained for non-DOM environments) --
+
+// Simple string-literal union types
+type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";
+type RequestCredentials = "include" | "omit" | "same-origin";
+type RequestMode = "cors" | "navigate" | "no-cors" | "same-origin";
+type RequestPriority = "auto" | "high" | "low";
+type RequestRedirect = "error" | "follow" | "manual";
+type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
+
+// Timer — opaque handle compatible with all runtimes
+type Timer = number | { ref(): void; unref(): void };
+
+// ReadableStream — minimal stub for body types
+interface ReadableStream<R = any> {
+  readonly locked: boolean;
+  getReader(): any;
+}
+
+// Fetch API interfaces — minimal subset covering usage in this package
+interface Headers {
+  append(name: string, value: string): void;
+  delete(name: string): void;
+  get(name: string): string | null;
+  has(name: string): boolean;
+  set(name: string, value: string): void;
+  forEach(callbackfn: (value: string, key: string, parent: Headers) => void): void;
+}
+type HeadersInit = [string, string][] | Record<string, string> | Headers;
+
+interface AbortSignal {
+  readonly aborted: boolean;
+  readonly reason: any;
+}
+
+interface AbortController {
+  readonly signal: AbortSignal;
+  abort(reason?: any): void;
+}
+
+interface Blob {
+  readonly size: number;
+  readonly type: string;
+  text(): Promise<string>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+declare var Blob: { new(blobParts?: any[], options?: any): Blob; prototype: Blob; };
+
+interface File extends Blob {
+  readonly name: string;
+  readonly lastModified: number;
+}
+declare var File: { new(fileBits: any[], fileName: string, options?: any): File; prototype: File; };
+
+interface URL {
+  href: string;
+  readonly origin: string;
+  protocol: string;
+  host: string;
+  hostname: string;
+  port: string;
+  pathname: string;
+  search: string;
+  hash: string;
+  toString(): string;
+}
+
+interface Response {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: Headers;
+  readonly body: ReadableStream<Uint8Array> | null;
+  readonly bodyUsed: boolean;
+  readonly url: string;
+  readonly redirected: boolean;
+  json(): Promise<any>;
+  text(): Promise<string>;
+  blob(): Promise<Blob>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  clone(): Response;
+}
+
+interface RequestInit {
+  method?: string;
+  headers?: HeadersInit;
+  body?: any;
+  mode?: RequestMode;
+  credentials?: RequestCredentials;
+  cache?: RequestCache;
+  redirect?: RequestRedirect;
+  referrer?: string;
+  referrerPolicy?: ReferrerPolicy;
+  integrity?: string;
+  keepalive?: boolean;
+  signal?: AbortSignal | null;
+  window?: null;
+  priority?: RequestPriority;
+  duplex?: string;
+}
+
+declare namespace globalThis {
+  interface Request {
+    readonly url: string;
+    readonly method: string;
+    readonly headers: Headers;
+    readonly body: ReadableStream<Uint8Array> | null;
+    clone(): globalThis.Request;
+  }
+}
+
+// -- End Fetch API type stubs --
+`;
+
 export default defineConfig({
 	entry: ["./src/index.ts"],
 	splitting: false,
 	sourcemap: true,
 	format: ["esm", "cjs"],
-	dts: true,
+	dts: {
+		banner: FETCH_API_STUBS,
+	},
 	clean: true,
 	external: ["zod"],
 });


### PR DESCRIPTION
## Problem

The built `.d.ts` references Fetch API types (`Response`, `Headers`, `RequestInit`, `AbortSignal`, `URL`, `Blob`, `File`, etc.) as bare identifiers from `lib.dom.d.ts`. Consumers whose tsconfig does not include `"DOM"` in `lib` — a standard configuration for backend projects using `lib: ["ESNext"]` — get **88 TS2304 errors** when `skipLibCheck: false`.

This has been reported before in the better-auth ecosystem: [better-auth#1550](https://github.com/better-auth/better-auth/issues/1550) mentions the `Timer` type leak from this package as one of the issues breaking `skipLibCheck: false` consumers.

### Reproduction

```bash
mkdir repro && cd repro
npm init -y
npm add @better-fetch/fetch@1.1.21 typescript@5
```

**tsconfig.json:**
```json
{
  "compilerOptions": {
    "strict": true,
    "skipLibCheck": false,
    "moduleResolution": "bundler",
    "module": "ESNext",
    "lib": ["ESNext"]
  }
}
```

**test.ts:**
```ts
import type { BetterFetchOption } from '@better-fetch/fetch';
export type { BetterFetchOption };
```

```
npx tsc --noEmit
# 88 errors: Cannot find name 'Response', 'Headers', 'RequestInit', ...
```

## Fix

Use tsup's native `dts.banner` option to prepend module-scoped Fetch API type stubs to the built `.d.ts` output. Since `.d.ts` files with `export` statements are ES modules, the prepended declarations are **file-scoped** — they shadow DOM globals when DOM is present (no conflicts) and provide the missing types when DOM is absent. No global namespace pollution.

**1 file changed** (`tsup.config.ts`), no new files, no build script changes.

### Types declared

Minimal stubs covering every Fetch API type referenced in the built output:

- String literal unions: `RequestCache`, `RequestCredentials`, `RequestMode`, `RequestPriority`, `RequestRedirect`, `ReferrerPolicy`
- Utility types: `Timer`, `HeadersInit`
- Interfaces: `ReadableStream`, `Headers`, `AbortSignal`, `AbortController`, `Blob`, `File`, `URL`, `Response`, `RequestInit`
- Class declarations: `declare var Blob`, `declare var File` (needed for `typeof` usage in `output` option)
- Namespace: `declare namespace globalThis { interface Request }` (needed for `FetchEsque` type)

### Why this approach

The package uses Fetch API types both as **type references** (`Response`, `Headers` in type positions) and as **runtime globals** (`new AbortController()`, `new Headers()`). The runtime usage is correct — all modern JS runtimes provide the Fetch API. The problem is only in the type declarations.

A source-level ambient `globals.d.ts` would pollute the global namespace and potentially conflict with consumers who have `lib: ["DOM"]`. Module-scoped stubs in the DTS output avoid this entirely.

## Verification

Verified on v1.1.21 (current npm release):

| Gate | Before | After |
|------|--------|-------|
| `tsc --noEmit` (upstream) | 0 errors | 0 errors |
| `pnpm build` (tsup) | ESM, CJS, DTS pass | ESM, CJS, DTS pass (DTS ~3 KB larger) |
| `vitest run` | 23 fail / 46 pass | 23 fail / 46 pass (identical, pre-existing AbortSignal issue) |
| Consumer `lib: ["ESNext"]` | **88 errors** | **0 errors** |
| Consumer `lib: ["ESNext", "DOM"]` | 0 errors | 0 errors |

## Note on CI

CI will fail due to a pre-existing build breakage on `main` — undefined `headers` variable in `utils.ts` (introduced in #65, tracked in #85, fix in #81). This PR does not touch `utils.ts`.
