### PR TITLE
chore: add MIT License to the repository

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 - present, Bereket Engida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### chore: Define license to fix OSV/License scanning

#### **Description**
While performing a security and license compliance audit using [OSV-Scanner](https://github.com/google/osv-scanner), `@better-fetch/fetch` was flagged with an **UNKNOWN** license status.

#### **Why this matters**
Many enterprise environments and automated CI/CD pipelines use tools like OSV-Scanner to enforce open-source compliance. When a package is marked as "UNKNOWN," it is often treated as "All Rights Reserved" by default, which can block the package from being used in many projects. 

#### **Evidence**
The following violation was caught during an OSV scan`:

| LICENSE VIOLATION | ECOSYSTEM | PACKAGE             | VERSION | SOURCE                |
| :---------------- | :-------- | :------------------ | :------ | :-------------------- |
| **UNKNOWN** | npm       | @better-fetch/fetch | 1.1.21  | src/package-lock.json |

Adding the license from better-auth/better-auth should be sufficient here since better-auth/package.json does not define the license (see https://github.com/better-auth/better-fetch/issues/89 for where this issue has also been raised.)

