### PR TITLE
fix(create-fetch): preserve Headers instances by sharing one mergeHeaders

### DIFF
--- a/packages/better-fetch/src/create-fetch/index.ts
+++ b/packages/better-fetch/src/create-fetch/index.ts
@@ -1,33 +1,8 @@
 import { betterFetch } from "../fetch";
 import { BetterFetchPlugin } from "../plugins";
 import type { BetterFetchOption } from "../types";
-import { parseStandardSchema } from "../utils";
+import { mergeHeaders, parseStandardSchema } from "../utils";
 import type { BetterFetch, CreateFetchOption } from "./types";
-
-const mergeHeaders = (
-	base?: Record<string, string | undefined>,
-	override?: Record<string, string | undefined>,
-): Record<string, string | undefined> => {
-	const result: Record<string, string | undefined> = {};
-	
-	if (base) {
-		for (const [key, value] of Object.entries(base)) {
-			if (value !== null && value !== undefined) {
-				result[key] = value;
-			}
-		}
-	}
-	
-	if (override) {
-		for (const [key, value] of Object.entries(override)) {
-			if (value !== null && value !== undefined) {
-				result[key] = value;
-			}
-		}
-	}
-	
-	return result;
-};
 
 export const applySchemaPlugin = (config: CreateFetchOption) =>
 	({

--- a/packages/better-fetch/src/test/create.test.ts
+++ b/packages/better-fetch/src/test/create.test.ts
@@ -660,3 +660,49 @@ describe("plugin", () => {
 		expectTypeOf(f).parameter(0).toMatchTypeOf<"/path">();
 	});
 });
+
+describe("create-fetch-headers", () => {
+	const captureHeaders = () => {
+		let received: Headers | undefined;
+		const customFetchImpl = async (_url: any, init?: RequestInit) => {
+			received = new Headers(init?.headers);
+			return new Response(null, { status: 200 });
+		};
+		return { customFetchImpl, get: () => received };
+	};
+
+	it("preserves headers passed as a Headers instance", async () => {
+		const { customFetchImpl, get } = captureHeaders();
+		const $fetch = createFetch({
+			baseURL: "http://localhost:4001",
+			customFetchImpl,
+		});
+		await $fetch("/x", {
+			headers: new Headers({ cookie: "session=abc", "x-test": "1" }),
+		});
+		expect(get()?.get("cookie")).toBe("session=abc");
+		expect(get()?.get("x-test")).toBe("1");
+	});
+
+	it("preserves headers passed as a plain object", async () => {
+		const { customFetchImpl, get } = captureHeaders();
+		const $fetch = createFetch({
+			baseURL: "http://localhost:4001",
+			customFetchImpl,
+		});
+		await $fetch("/x", { headers: { cookie: "session=abc" } });
+		expect(get()?.get("cookie")).toBe("session=abc");
+	});
+
+	it("merges config headers with per-call Headers instance", async () => {
+		const { customFetchImpl, get } = captureHeaders();
+		const $fetch = createFetch({
+			baseURL: "http://localhost:4001",
+			headers: { "x-base": "base" },
+			customFetchImpl,
+		});
+		await $fetch("/x", { headers: new Headers({ cookie: "session=abc" }) });
+		expect(get()?.get("x-base")).toBe("base");
+		expect(get()?.get("cookie")).toBe("session=abc");
+	});
+});

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -101,29 +101,31 @@ export function isRouteMethod(method?: string) {
 	return routeMethod.includes(method.toUpperCase());
 }
 
-function mergeHeaders(
-	target: Headers,
-	source?: BetterFetchOption["headers"] | Record<string, string>,
-) {
-	if (!source) {
-		return;
-	}
-	if (source instanceof Headers) {
-		source.forEach((value, key) => target.set(key, value));
-		return;
-	}
-	const entries = Array.isArray(source) ? source : Object.entries(source);
-	for (const [key, value] of entries) {
-		if (value !== null && value !== undefined) {
-			target.set(key, value);
+export function mergeHeaders(
+	...sources: (HeadersInit | Record<string, string | undefined> | undefined)[]
+): Headers {
+	const merged = new Headers();
+	for (const source of sources) {
+		if (!source) {
+			continue;
+		}
+		// Object.entries/spread on a Headers instance yields nothing, dropping it.
+		if (source instanceof Headers) {
+			source.forEach((value, key) => merged.set(key, value));
+		} else {
+			const entries = Array.isArray(source) ? source : Object.entries(source);
+			for (const [key, value] of entries) {
+				if (value !== null && value !== undefined) {
+					merged.set(key, value);
+				}
+			}
 		}
 	}
+	return merged;
 }
 
 export async function getHeaders(opts?: BetterFetchOption) {
-	const headers = new Headers();
-	mergeHeaders(headers, opts?.headers);
-	mergeHeaders(headers, await getAuthHeader(opts));
+	const headers = mergeHeaders(opts?.headers, await getAuthHeader(opts));
 
 	if (!headers.has("content-type")) {
 		const contentType = detectContentType(opts?.body);


### PR DESCRIPTION
Fixes a regression from #65:

createFetch `mergeHeaders` used `Object.entries`, which yields nothing on a `Headers` instance -> silently dropping headers passed that way (cookies/session lost, breaking better-auth #9955). Unifies header merging into one Headers-aware `mergeHeaders`.