### PR TITLE
fix(create-fetch): keep `options.headers` a plain object so plugins can spread it

### DIFF
--- a/packages/better-fetch/src/test/create.test.ts
+++ b/packages/better-fetch/src/test/create.test.ts
@@ -705,4 +705,25 @@ describe("create-fetch-headers", () => {
 		expect(get()?.get("x-base")).toBe("base");
 		expect(get()?.get("cookie")).toBe("session=abc");
 	});
+
+	it("exposes options.headers to plugins as a spreadable plain object", async () => {
+		// The electron/expo client plugins spread `options.headers`; a `Headers`
+		// instance would spread to `{}` and drop the user's headers.
+		let spread: Record<string, string> | undefined;
+		const inspectPlugin: BetterFetchPlugin = {
+			id: "inspect",
+			name: "inspect",
+			async init(url, options) {
+				spread = { ...(options?.headers as Record<string, string>) };
+				return { url, options };
+			},
+		};
+		const $fetch = createFetch({
+			baseURL: "http://localhost:4001",
+			customFetchImpl: async () => new Response(null, { status: 200 }),
+			plugins: [inspectPlugin],
+		});
+		await $fetch("/x", { headers: new Headers({ "x-user": "u" }) });
+		expect(spread).toEqual({ "x-user": "u" });
+	});
 });

--- a/packages/better-fetch/src/utils.ts
+++ b/packages/better-fetch/src/utils.ts
@@ -103,20 +103,23 @@ export function isRouteMethod(method?: string) {
 
 export function mergeHeaders(
 	...sources: (HeadersInit | Record<string, string | undefined> | undefined)[]
-): Headers {
-	const merged = new Headers();
+): Record<string, string> {
+	const merged: Record<string, string> = {};
 	for (const source of sources) {
 		if (!source) {
 			continue;
 		}
-		// Object.entries/spread on a Headers instance yields nothing, dropping it.
+		// Headers has no enumerable keys (Object.entries/spread drops it); the
+		// result stays a plain object so plugins can spread `options.headers`.
 		if (source instanceof Headers) {
-			source.forEach((value, key) => merged.set(key, value));
+			source.forEach((value, key) => {
+				merged[key] = value;
+			});
 		} else {
 			const entries = Array.isArray(source) ? source : Object.entries(source);
 			for (const [key, value] of entries) {
 				if (value !== null && value !== undefined) {
-					merged.set(key, value);
+					merged[key] = value;
 				}
 			}
 		}
@@ -125,7 +128,7 @@ export function mergeHeaders(
 }
 
 export async function getHeaders(opts?: BetterFetchOption) {
-	const headers = mergeHeaders(opts?.headers, await getAuthHeader(opts));
+	const headers = new Headers(mergeHeaders(opts?.headers, await getAuthHeader(opts)));
 
 	if (!headers.has("content-type")) {
 		const contentType = detectContentType(opts?.body);


### PR DESCRIPTION
related to `better-auth/better-auth` electron, expo plugin client