### PR TITLE
Add package license metadata

### DIFF
--- a/packages/better-fetch/package.json
+++ b/packages/better-fetch/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@better-fetch/fetch",
 	"version": "1.2.2",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/better-auth/better-fetch.git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@better-fetch/logger",
 	"version": "1.2.2",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/better-auth/better-fetch.git",


### PR DESCRIPTION
## Summary
- add MIT license metadata to public package manifests
- align package metadata with the repository/package MIT license text

## Verification
- npm pack --dry-run --ignore-scripts --json for both updated package directories
- node package manifest assertion
- git diff --check