### PR TITLE
test: polish logger tests with setup helper and typed mocks

### DIFF
--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,6 +1,6 @@
+import { type FetchEsque, createFetch } from "@better-fetch/fetch";
 import { describe, expect, it, vi } from "vitest";
-import { createFetch } from "@better-fetch/fetch";
-import { logger } from "../src/index";
+import { type LoggerOptions, logger } from "../src/index";
 
 function mockConsole() {
 	return {
@@ -12,7 +12,7 @@ function mockConsole() {
 	};
 }
 
-function createMockFetch(status: number, body?: any) {
+function mockFetch(status: number, body?: unknown): FetchEsque {
 	return async () =>
 		new Response(body !== undefined ? JSON.stringify(body) : null, {
 			status,
@@ -20,14 +20,28 @@ function createMockFetch(status: number, body?: any) {
 		});
 }
 
+function setup(
+	loggerOptions: LoggerOptions = {},
+	fetchImpl: FetchEsque = mockFetch(200, { ok: true }),
+) {
+	const cons = mockConsole();
+	const $fetch = createFetch({
+		baseURL: "http://localhost:3000",
+		plugins: [logger({ console: cons, ...loggerOptions })],
+		customFetchImpl: fetchImpl,
+	});
+	return { cons, $fetch };
+}
+
+const messageOf = (fn: { mock: { calls: unknown[][] } }, index = 0): string =>
+	fn.mock.calls[index]?.[0] as string;
+
+const messagesOf = (fn: { mock: { calls: unknown[][] } }): string[] =>
+	fn.mock.calls.map((call) => call[0] as string);
+
 describe("logger - default format", () => {
 	it("logs method and url on request", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup();
 
 		await $fetch("/users");
 
@@ -37,17 +51,12 @@ describe("logger - default format", () => {
 	});
 
 	it("logs method, url, status and duration on success", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup();
 
 		await $fetch("/users");
 
 		expect(cons.success).toHaveBeenCalledTimes(1);
-		const msg = cons.success.mock.calls[0][0] as string;
+		const msg = messageOf(cons.success);
 		expect(msg).toContain("[GET] http://localhost:3000/users");
 		expect(msg).toContain("200");
 		expect(msg).toContain("OK");
@@ -55,17 +64,15 @@ describe("logger - default format", () => {
 	});
 
 	it("logs method, url, status and duration on error", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons })],
-			customFetchImpl: createMockFetch(404, { message: "not found" }),
-		});
+		const { cons, $fetch } = setup(
+			{},
+			mockFetch(404, { message: "not found" }),
+		);
 
 		await $fetch("/missing");
 
 		expect(cons.fail).toHaveBeenCalledTimes(1);
-		const msg = cons.fail.mock.calls[0][0] as string;
+		const msg = messageOf(cons.fail);
 		expect(msg).toContain("[GET] http://localhost:3000/missing");
 		expect(msg).toContain("404");
 		expect(msg).toContain("Not Found");
@@ -73,107 +80,63 @@ describe("logger - default format", () => {
 	});
 
 	it("includes POST method for post requests", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup();
 
 		await $fetch("/users", { method: "POST", body: { name: "test" } });
 
-		expect(cons.log).toHaveBeenCalledWith(
-			expect.stringContaining("[POST]"),
-		);
+		expect(cons.log).toHaveBeenCalledWith(expect.stringContaining("[POST]"));
 		expect(cons.success).toHaveBeenCalledWith(
 			expect.stringContaining("[POST]"),
 		);
 	});
 
 	it("logs verbose data on success", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons, verbose: true })],
-			customFetchImpl: createMockFetch(200, { id: 1 }),
-		});
+		const { cons, $fetch } = setup(
+			{ verbose: true },
+			mockFetch(200, { id: 1 }),
+		);
 
 		await $fetch("/users");
 
-		// success line + verbose data line
 		expect(cons.success).toHaveBeenCalledTimes(1);
 		expect(cons.log).toHaveBeenCalledWith({ id: 1 });
 	});
 
-	it("logs verbose error body on error", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [
-				logger({
-					console: cons,
-					verbose: true,
-				}),
-			],
-			customFetchImpl: createMockFetch(500, { error: "boom" }),
-		});
+	it("logs the error line on error", async () => {
+		const { cons, $fetch } = setup(
+			{ verbose: true },
+			mockFetch(500, { error: "boom" }),
+		);
 
 		await $fetch("/fail");
 
 		expect(cons.fail).toHaveBeenCalledTimes(1);
-		// verbose error body clones the response internally;
-		// happy-dom doesn't support cloning an already-consumed body,
-		// so we just verify the error log line was emitted
-		const msg = cons.fail.mock.calls[0][0] as string;
+		const msg = messageOf(cons.fail);
 		expect(msg).toContain("[GET] http://localhost:3000/fail");
 		expect(msg).toContain("500");
 	});
 
-	it("parallel requests produce distinguishable logs", async () => {
-		const cons = mockConsole();
-		const customFetch = async (url: string | URL) => {
-			const path = url.toString();
-			if (path.includes("/slow")) {
+	it("produces one distinguishable log per parallel request", async () => {
+		const slowFast: FetchEsque = async (input) => {
+			if (input.toString().includes("/slow")) {
 				await new Promise((r) => setTimeout(r, 50));
-				return new Response(JSON.stringify({ slow: true }), {
-					status: 200,
-					statusText: "OK",
-				});
 			}
-			return new Response(JSON.stringify({ fast: true }), {
-				status: 200,
-				statusText: "OK",
-			});
+			return new Response(null, { status: 200, statusText: "OK" });
 		};
-
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons })],
-			customFetchImpl: customFetch as any,
-		});
+		const { cons, $fetch } = setup({}, slowFast);
 
 		await Promise.all([$fetch("/slow"), $fetch("/fast")]);
 
-		const successMessages = cons.success.mock.calls.map(
-			(c: any[]) => c[0] as string,
-		);
-		expect(successMessages).toHaveLength(2);
-
-		const slowLog = successMessages.find((m) => m.includes("/slow"));
-		const fastLog = successMessages.find((m) => m.includes("/fast"));
-		expect(slowLog).toBeDefined();
-		expect(fastLog).toBeDefined();
+		const messages = messagesOf(cons.success);
+		expect(messages).toHaveLength(2);
+		expect(messages.filter((m) => m.includes("/slow"))).toHaveLength(1);
+		expect(messages.filter((m) => m.includes("/fast"))).toHaveLength(1);
 	});
 });
 
 describe("logger - legacy format", () => {
 	it("logs the original request message", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons, logFormat: "legacy" })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup({ logFormat: "legacy" });
 
 		await $fetch("/users");
 
@@ -184,12 +147,7 @@ describe("logger - legacy format", () => {
 	});
 
 	it("logs the original success message", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons, logFormat: "legacy" })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup({ logFormat: "legacy" });
 
 		await $fetch("/users");
 
@@ -199,12 +157,10 @@ describe("logger - legacy format", () => {
 	});
 
 	it("logs the original error message", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons, logFormat: "legacy" })],
-			customFetchImpl: createMockFetch(404, { message: "not found" }),
-		});
+		const { cons, $fetch } = setup(
+			{ logFormat: "legacy" },
+			mockFetch(404, { message: "not found" }),
+		);
 
 		await $fetch("/missing");
 
@@ -218,12 +174,7 @@ describe("logger - legacy format", () => {
 
 describe("logger - disabled", () => {
 	it("does not log when disabled", async () => {
-		const cons = mockConsole();
-		const $fetch = createFetch({
-			baseURL: "http://localhost:3000",
-			plugins: [logger({ console: cons, enabled: false })],
-			customFetchImpl: createMockFetch(200, { ok: true }),
-		});
+		const { cons, $fetch } = setup({ enabled: false });
 
 		await $fetch("/users");
 


### PR DESCRIPTION
Extract a setup() helper to remove repeated createFetch wiring, type the fetch mock as FetchEsque, centralize message extraction, and strengthen the parallel-request assertion to count distinguishable lines instead of a weak toBeDefined check.