### PR TITLE
feat: add a per-request context store shared across hooks

### DIFF
--- a/packages/better-fetch/src/fetch.ts
+++ b/packages/better-fetch/src/fetch.ts
@@ -1,5 +1,5 @@
 import { BetterFetchError } from "./error";
-import { initializePlugins } from "./plugins";
+import { type RequestContext, initializePlugins } from "./plugins";
 import { createRetryStrategy } from "./retry";
 import type { StandardSchemaV1 } from "./standard-schema";
 import type { BetterFetchOption, BetterFetchResponse } from "./types";
@@ -44,13 +44,19 @@ export const betterFetch = async <
 	const headers = await getHeaders(opts);
 	const body = getBody(opts, headers);
 	const method = getMethod(__url, opts);
-	let context = {
+	// fresh per request so concurrent requests never share state
+	const store: Record<string, unknown> = Object.assign(
+		Object.create(null),
+		opts.context,
+	);
+	let context: RequestContext = {
 		...opts,
 		url: _url,
 		headers,
 		body,
 		method,
 		signal,
+		context: store,
 	};
 	/**
 	 * Run all on request hooks
@@ -60,6 +66,7 @@ export const betterFetch = async <
 			const res = await onRequest(context);
 			if (typeof res === "object" && res !== null) {
 				context = res;
+				context.context = store; // re-anchor after replacement
 			}
 		}
 	}

--- a/packages/better-fetch/src/types.ts
+++ b/packages/better-fetch/src/types.ts
@@ -5,7 +5,9 @@ import { StandardSchemaV1 } from "./standard-schema";
 import type { Prettify, StringLiteralUnion } from "./type-utils";
 
 type CommonHeaders = {
-	accept?: StringLiteralUnion<"application/json" | "text/plain" | "application/octet-stream">;
+	accept?: StringLiteralUnion<
+		"application/json" | "text/plain" | "application/octet-stream"
+	>;
 	"content-type"?: StringLiteralUnion<
 		| "application/json"
 		| "text/plain"
@@ -144,6 +146,8 @@ export type BetterFetchOption<
 			 * Abort signal
 			 */
 			signal?: AbortSignal | null;
+			/** Per-request store shared across hooks; stable across context replacement. */
+			context?: Record<string, unknown>;
 		}
 >;
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -64,14 +64,37 @@ const defaultConsole: ConsoleEsque = {
 	},
 };
 
+const START = "@better-fetch/logger.start";
+
 function formatPrefix(method: string, url: string | URL): string {
 	return `[${method.toUpperCase()}] ${url.toString()}`;
 }
 
-function formatDuration(startTime: number | undefined): string {
-	if (startTime === undefined) return "";
-	const ms = Date.now() - startTime;
-	return ` (${ms}ms)`;
+function formatLine(
+	request: {
+		method: string;
+		url: string | URL;
+		context?: Record<string, unknown>;
+	},
+	response: Response,
+): string {
+	const status = response.status;
+	const statusText = response.statusText || getStatusText(status);
+	const start = request.context?.[START];
+	const duration =
+		typeof start === "number" ? ` (${Date.now() - start}ms)` : "";
+	return `${formatPrefix(
+		request.method,
+		request.url,
+	)} — ${status} ${statusText}${duration}`;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+	try {
+		return await response.clone().json();
+	} catch {
+		return undefined;
+	}
 }
 
 export const logger = (options?: LoggerOptions) => {
@@ -83,7 +106,6 @@ export const logger = (options?: LoggerOptions) => {
 	};
 	const { enabled } = opts;
 	const isLegacy = opts.logFormat === "legacy";
-	const startTimes = new WeakMap<object, number>();
 
 	return {
 		id: "logger",
@@ -92,17 +114,14 @@ export const logger = (options?: LoggerOptions) => {
 		hooks: {
 			onRequest(context) {
 				if (!enabled) return;
-				startTimes.set(context, Date.now());
+				if (context.context) {
+					context.context[START] = Date.now();
+				}
 				if (isLegacy) {
-					opts.console.log(
-						"Request being sent to:",
-						context.url.toString(),
-					);
+					opts.console.log("Request being sent to:", context.url.toString());
 					return;
 				}
-				opts.console.log(
-					formatPrefix(context.method, context.url),
-				);
+				opts.console.log(formatPrefix(context.method, context.url));
 			},
 			async onSuccess(context) {
 				if (!enabled) return;
@@ -111,15 +130,7 @@ export const logger = (options?: LoggerOptions) => {
 					log("Request succeeded", context.data);
 					return;
 				}
-				const duration = formatDuration(
-					startTimes.get(context.request),
-				);
-				const status = context.response.status;
-				const statusText =
-					context.response.statusText || getStatusText(status);
-				log(
-					`${formatPrefix(context.request.method, context.request.url)} — ${status} ${statusText}${duration}`,
-				);
+				log(formatLine(context.request, context.response));
 				if (opts.verbose) {
 					opts.console.log(context.data);
 				}
@@ -127,65 +138,34 @@ export const logger = (options?: LoggerOptions) => {
 			onRetry(response) {
 				if (!enabled) return;
 				const log = opts.console.warn || opts.console.log;
+				const attempt = (response.request.retryAttempt || 0) + 1;
 				if (isLegacy) {
-					log(
-						"Retrying request...",
-						"Attempt:",
-						(response.request.retryAttempt || 0) + 1,
-					);
+					log("Retrying request...", "Attempt:", attempt);
 					return;
 				}
-				const attempt = (response.request.retryAttempt || 0) + 1;
 				log(
-					`${formatPrefix(response.request.method, response.request.url)} — Retry attempt #${attempt}`,
+					`${formatPrefix(
+						response.request.method,
+						response.request.url,
+					)} — Retry attempt #${attempt}`,
 				);
 			},
 			async onError(context) {
 				if (!enabled) return;
 				const log = opts.console.fail || opts.console.error;
+				const body = opts.verbose
+					? await parseBody(context.response)
+					: undefined;
 				if (isLegacy) {
-					let obj: any;
-					try {
-						if (opts.verbose) {
-							const res = context.response.clone();
-							const json = await res.json();
-							if (json) {
-								obj = json;
-							}
-						}
-					} catch (e) {}
-					log(
-						"Request failed with status: ",
-						context.response.status,
-						`(${
-							context.response.statusText ||
-							getStatusText(context.response.status)
-						})`,
-					);
-					opts.verbose && obj && opts.console.error(obj);
-					return;
+					const status = context.response.status;
+					const statusText =
+						context.response.statusText || getStatusText(status);
+					log("Request failed with status: ", status, `(${statusText})`);
+				} else {
+					log(formatLine(context.request, context.response));
 				}
-				const duration = formatDuration(
-					startTimes.get(context.request),
-				);
-				const status = context.response.status;
-				const statusText =
-					context.response.statusText || getStatusText(status);
-				log(
-					`${formatPrefix(context.request.method, context.request.url)} — ${status} ${statusText}${duration}`,
-				);
-				if (opts.verbose) {
-					let obj: any;
-					try {
-						const res = context.response.clone();
-						const json = await res.json();
-						if (json) {
-							obj = json;
-						}
-					} catch (e) {}
-					if (obj) {
-						opts.console.error(obj);
-					}
+				if (body) {
+					opts.console.error(body);
 				}
 			},
 		},

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,4 +1,8 @@
-import { type FetchEsque, createFetch } from "@better-fetch/fetch";
+import {
+	type BetterFetchPlugin,
+	type FetchEsque,
+	createFetch,
+} from "@better-fetch/fetch";
 import { describe, expect, it, vi } from "vitest";
 import { type LoggerOptions, logger } from "../src/index";
 
@@ -182,5 +186,89 @@ describe("logger - disabled", () => {
 		expect(cons.success).not.toHaveBeenCalled();
 		expect(cons.fail).not.toHaveBeenCalled();
 		expect(cons.error).not.toHaveBeenCalled();
+	});
+});
+
+describe("logger - per-request store", () => {
+	it("keeps duration when another plugin replaces the request context", async () => {
+		const cons = mockConsole();
+		// onRequest returns a fresh context that drops the store
+		const replaceContext = {
+			id: "replace",
+			name: "replace",
+			hooks: {
+				onRequest(context) {
+					return { ...context, context: undefined };
+				},
+			},
+		} satisfies BetterFetchPlugin;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			plugins: [logger({ console: cons }), replaceContext],
+			customFetchImpl: mockFetch(200, { ok: true }),
+		});
+
+		await $fetch("/users");
+
+		expect(cons.success).toHaveBeenCalledTimes(1);
+		expect(messageOf(cons.success)).toMatch(/\(\d+ms\)/);
+	});
+
+	it("isolates the store per request even with a shared default context", async () => {
+		const seen: string[] = [];
+		const probe = {
+			id: "probe",
+			name: "probe",
+			hooks: {
+				onRequest(context) {
+					if (context.context) {
+						context.context.path = context.url.toString();
+					}
+				},
+				onSuccess(context) {
+					seen.push(context.request.context?.path as string);
+				},
+			},
+		} satisfies BetterFetchPlugin;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			context: {}, // shared default
+			plugins: [probe],
+			customFetchImpl: async (input) => {
+				if (input.toString().includes("/a")) {
+					await new Promise((r) => setTimeout(r, 30));
+				}
+				return new Response(null, { status: 200 });
+			},
+		});
+
+		await Promise.all([$fetch("/a"), $fetch("/b")]);
+
+		expect([...seen].sort()).toEqual([
+			"http://localhost:3000/a",
+			"http://localhost:3000/b",
+		]);
+	});
+
+	it("exposes a null-prototype store with no inherited keys", async () => {
+		let inherited: unknown = "sentinel";
+		const probe = {
+			id: "proto",
+			name: "proto",
+			hooks: {
+				onRequest(context) {
+					inherited = context.context?.toString;
+				},
+			},
+		} satisfies BetterFetchPlugin;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			plugins: [probe],
+			customFetchImpl: mockFetch(200, { ok: true }),
+		});
+
+		await $fetch("/x");
+
+		expect(inherited).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Adds `options.context`: a per-request key-value store available in every hook as `context.context`, kept stable even when a hook replaces the request context (cf. Hono's c.set/c.get and ky's options.context).

The logger now stores the request start time there instead of a WeakMap keyed by the replaceable context object, so duration survives when other plugins rewrite the context. Also dedups the logger via formatLine/parseBody helpers.