### PR TITLE
chore: add package support metadata

### DIFF
--- a/packages/better-fetch/package.json
+++ b/packages/better-fetch/package.json
@@ -2,6 +2,10 @@
 	"name": "@better-fetch/fetch",
 	"version": "1.3.1",
 	"license": "MIT",
+	"homepage": "https://github.com/better-auth/better-fetch/tree/main/packages/better-fetch#readme",
+	"bugs": {
+		"url": "https://github.com/better-auth/better-fetch/issues"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/better-auth/better-fetch.git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -2,6 +2,10 @@
 	"name": "@better-fetch/logger",
 	"version": "1.3.1",
 	"license": "MIT",
+	"homepage": "https://github.com/better-auth/better-fetch/tree/main/packages/logger",
+	"bugs": {
+		"url": "https://github.com/better-auth/better-fetch/issues"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/better-auth/better-fetch.git",


### PR DESCRIPTION
## Summary
- add `homepage` and `bugs.url` metadata for `@better-fetch/fetch`
- add `homepage` and `bugs.url` metadata for `@better-fetch/logger`
- leave runtime code, dependencies, package versions, entry points, and published file globs unchanged

## Validation
- package metadata assertion for both package manifests
- `git diff --check`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @better-fetch/fetch typecheck`
- `corepack pnpm --filter @better-fetch/fetch build`
- `corepack pnpm --filter @better-fetch/logger typecheck`
- `corepack pnpm --filter @better-fetch/logger build`
- `npm pack --dry-run --ignore-scripts --json ./packages/better-fetch`
- `npm pack --dry-run --ignore-scripts --json ./packages/logger`
