### PR TITLE
chore: add fetch package support metadata

### DIFF
--- a/packages/better-fetch/package.json
+++ b/packages/better-fetch/package.json
@@ -2,10 +2,14 @@
 	"name": "@better-fetch/fetch",
 	"version": "1.3.1",
 	"license": "MIT",
+	"homepage": "https://github.com/better-auth/better-fetch/tree/main/packages/better-fetch#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/better-auth/better-fetch.git",
 		"directory": "packages/better-fetch"
+	},
+	"bugs": {
+		"url": "https://github.com/better-auth/better-fetch/issues"
 	},
 	"main": "./dist/index.cjs",
 	"type": "module",


### PR DESCRIPTION
## Summary

- Adds `homepage` metadata for `@better-fetch/fetch`
- Adds `bugs.url` metadata pointing to the repository issue tracker

## Why

The package already declares its repository and package directory, but the published npm metadata does not expose direct README/support links. These fields help npm users find the package docs and report issues from package manager metadata.

## Validation

- Parsed `packages/better-fetch/package.json` with Node
- Confirmed the new `homepage` and `bugs.url` values
- Ran `git diff --check`

No runtime code, dependencies, exports, or build outputs were changed.
